### PR TITLE
feat: add spotify playlist search and functionality for non supporte browsers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ secrets.env
 .env.local
 .vscode
 spotify-clonehero-next/raw_db_files
+node_modules/

--- a/spotify-clonehero-next/app/SupportedBrowserWarning.tsx
+++ b/spotify-clonehero-next/app/SupportedBrowserWarning.tsx
@@ -1,30 +1,184 @@
 'use client';
 
 import {useState, useEffect} from 'react';
+import {detectBrowserCapabilities, type BrowserCapabilities} from '@/lib/browser-compat/FileSystemCompat';
+import {Card, CardContent, CardDescription, CardHeader, CardTitle} from '@/components/ui/card';
+import {Badge} from '@/components/ui/badge';
+import {Alert, AlertDescription, AlertTitle} from '@/components/ui/alert';
+import {Info, CheckCircle, XCircle, AlertTriangle} from 'lucide-react';
 
 export default function SupportedBrowserWarning({
   children,
 }: {
   children?: React.ReactNode;
 }) {
-  const [isSupported, setIsSupported] = useState(true);
+  const [capabilities, setCapabilities] = useState<BrowserCapabilities | null>(null);
 
   useEffect(() => {
-    const DIRECTORY_PICKER_SUPPROTED =
-      typeof window !== 'undefined' &&
-      typeof window.showDirectoryPicker === 'function';
-
-    setIsSupported(DIRECTORY_PICKER_SUPPROTED);
+    setCapabilities(detectBrowserCapabilities());
   }, []);
 
-  if (!isSupported) {
+  if (!capabilities) {
+    return null; // Loading
+  }
+
+  const getBrowserName = (): string => {
+    if (typeof window === 'undefined') return 'Unknown';
+    
+    const userAgent = window.navigator.userAgent;
+    if (userAgent.includes('Chrome') && !userAgent.includes('Edg')) return 'Chrome';
+    if (userAgent.includes('Firefox')) return 'Firefox';
+    if (userAgent.includes('Safari') && !userAgent.includes('Chrome')) return 'Safari';
+    if (userAgent.includes('Edg')) return 'Edge';
+    if (userAgent.includes('Opera')) return 'Opera';
+    return 'Unknown';
+  };
+
+  const getCompatibilityMessage = () => {
+    switch (capabilities.mode) {
+      case 'native':
+        return {
+          type: 'success' as const,
+          title: 'Full Compatibility',
+          description: 'Your browser supports all features including directory access and file downloads.',
+        };
+      case 'fallback':
+        return {
+          type: 'warning' as const,
+          title: 'Limited Compatibility',
+          description: 'Your browser supports most features with some limitations. File system access will use fallback methods.',
+        };
+      case 'unsupported':
+        return {
+          type: 'error' as const,
+          title: 'Unsupported Browser',
+          description: 'Your browser does not support the required file system APIs.',
+        };
+    }
+  };
+
+  const message = getCompatibilityMessage();
+
+  if (capabilities.mode === 'unsupported') {
     return (
-      <p className="text-lg text-red-700 mt-2">
-        Warning: These tools will not work on your browser. It requires some
-        APIs that currently only exist in Chrome based browsers.
-      </p>
+      <div className="space-y-4">
+        <Alert variant="destructive">
+          <XCircle className="h-4 w-4" />
+          <AlertTitle>{message.title}</AlertTitle>
+          <AlertDescription>
+            {message.description} Please use a supported browser like Chrome, Edge, or Opera.
+          </AlertDescription>
+        </Alert>
+        
+        <Card>
+          <CardHeader>
+            <CardTitle>Browser Compatibility</CardTitle>
+            <CardDescription>Current browser: {getBrowserName()}</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <div className="text-sm text-muted-foreground">
+              <p className="mb-2">Supported browsers:</p>
+              <ul className="list-disc list-inside space-y-1">
+                <li>Google Chrome (recommended)</li>
+                <li>Microsoft Edge</li>
+                <li>Opera</li>
+                <li>Brave Browser (with limited features)</li>
+              </ul>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
     );
   }
 
-  return children ?? null;
+  return (
+    <div className="space-y-4">
+      {capabilities.mode === 'fallback' && (
+        <Alert>
+          <AlertTriangle className="h-4 w-4" />
+          <AlertTitle>{message.title}</AlertTitle>
+          <AlertDescription>
+            {message.description}
+          </AlertDescription>
+        </Alert>
+      )}
+
+      <Card className="mb-4">
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            Browser Compatibility Status
+            {capabilities.mode === 'native' ? (
+              <CheckCircle className="h-5 w-5 text-green-500" />
+            ) : capabilities.mode === 'fallback' ? (
+              <AlertTriangle className="h-5 w-5 text-yellow-500" />
+            ) : (
+              <XCircle className="h-5 w-5 text-red-500" />
+            )}
+          </CardTitle>
+          <CardDescription>
+            Current browser: {getBrowserName()} • Mode: {capabilities.mode}
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="grid grid-cols-2 md:grid-cols-3 gap-4">
+            <div className="flex items-center justify-between">
+              <span className="text-sm">Directory Access</span>
+              <Badge variant={capabilities.canReadDirectories ? 'default' : 'destructive'}>
+                {capabilities.canReadDirectories ? 'Supported' : 'Not Supported'}
+              </Badge>
+            </div>
+            
+            <div className="flex items-center justify-between">
+              <span className="text-sm">File Downloads</span>
+              <Badge variant={capabilities.canDownloadFiles ? 'default' : 'destructive'}>
+                {capabilities.canDownloadFiles ? 'Supported' : 'Not Supported'}
+              </Badge>
+            </div>
+            
+            <div className="flex items-center justify-between">
+              <span className="text-sm">File Writing</span>
+              <Badge variant={capabilities.canWriteFiles ? 'default' : 'secondary'}>
+                {capabilities.canWriteFiles ? 'Native' : 'Download Only'}
+              </Badge>
+            </div>
+            
+            <div className="flex items-center justify-between">
+              <span className="text-sm">Directory Picker</span>
+              <Badge variant={capabilities.supportsDirectoryPicker ? 'default' : 'secondary'}>
+                {capabilities.supportsDirectoryPicker ? 'Native' : 'Fallback'}
+              </Badge>
+            </div>
+            
+            <div className="flex items-center justify-between">
+              <span className="text-sm">Drag & Drop</span>
+              <Badge variant={capabilities.supportsDragAndDrop ? 'default' : 'destructive'}>
+                {capabilities.supportsDragAndDrop ? 'Supported' : 'Not Supported'}
+              </Badge>
+            </div>
+          </div>
+
+          {capabilities.mode === 'fallback' && (
+            <div className="mt-4 p-3 bg-yellow-50 dark:bg-yellow-900/20 rounded-lg">
+              <div className="flex items-start gap-2">
+                <Info className="h-4 w-4 text-yellow-600 dark:text-yellow-400 mt-0.5" />
+                <div className="text-sm">
+                  <p className="font-medium text-yellow-800 dark:text-yellow-200 mb-1">
+                    Fallback Mode Information
+                  </p>
+                  <ul className="text-yellow-700 dark:text-yellow-300 space-y-1 text-xs">
+                    <li>• You&#39;ll need to manually select folders using file dialogs</li>
+                    <li>• Files will be downloaded instead of saved directly to folders</li>
+                    <li>• Some advanced features may be limited</li>
+                    <li>• For the best experience, consider using Chrome or Edge</li>
+                  </ul>
+                </div>
+              </div>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      {children}
+    </div>
+  );
 }

--- a/spotify-clonehero-next/app/layout.tsx
+++ b/spotify-clonehero-next/app/layout.tsx
@@ -8,6 +8,7 @@ import {cn} from '@/lib/utils';
 import {Icons} from '@/components/icons';
 import {Button} from '@/components/ui/button';
 import {Toaster} from 'sonner';
+import GlobalHeader from '@/components/GlobalHeader';
 
 const fontSans = FontSans({
   subsets: ['latin'],
@@ -27,48 +28,12 @@ export default function RootLayout({children}: {children: React.ReactNode}) {
           'bg-background flex flex-col h-screen font-sans antialiased',
           fontSans.variable,
         )}>
-        <nav className="border-b border-border/60 h-12 md:h-16 px-4 md:px-8">
-          <div className="max-w-screen-xl flex flex-wrap items-center justify-between mx-auto h-full">
-            <div className="flex flex-row gap-8">
-              <Link
-                href="/"
-                className="flex items-center space-x-3 rtl:space-x-reverse">
-                <span className="self-center text-xl font-semibold whitespace-nowrap dark:text-white">
-                  Music Charts Tools
-                </span>
-              </Link>
-              <Link href="/">
-                <Button variant="ghost" className="font-semibold">
-                  <span className="">More Tools</span>
-                </Button>
-              </Link>
-            </div>
-
-            <nav className="flex items-center">
-              <Link
-                href="https://discord.gg/EDxu95B98s"
-                target="_blank"
-                rel="noreferrer">
-                <Button variant="ghost" size="icon" className="w-9 px-0">
-                  <Icons.discord className="h-4 w-4" />
-                  <span className="sr-only">Discord</span>
-                </Button>
-              </Link>
-              <Link
-                href="https://github.com/TheSavior/spotify-clonehero"
-                target="_blank"
-                rel="noreferrer">
-                <Button variant="ghost" size="icon" className="w-9 px-0">
-                  <Icons.gitHub className="h-4 w-4" />
-                  <span className="sr-only">GitHub</span>
-                </Button>
-              </Link>
-            </nav>
-          </div>
-        </nav>
-        <main className="flex flex-col flex-1 items-center align-center min-h-0 p-4">
-          <ContextProviders>{children}</ContextProviders>
-        </main>
+          <ContextProviders>
+            <GlobalHeader />
+              <main className="flex flex-col flex-1 items-center align-center min-h-0 p-4">
+                  {children}
+              </main>
+          </ContextProviders>
         <Toaster />
         <GoogleAnalytics gaId="G-LEE7EDJH14" />
       </body>

--- a/spotify-clonehero-next/app/page.tsx
+++ b/spotify-clonehero-next/app/page.tsx
@@ -10,7 +10,6 @@ import {
 } from '@/components/ui/card';
 import {Button, buttonVariants} from '@/components/ui/button';
 import {RxExternalLink} from 'react-icons/rx';
-import SupportedBrowserWarning from './SupportedBrowserWarning';
 
 export default function Home() {
   return (
@@ -27,8 +26,6 @@ export default function Home() {
           custom applications on your computer. Manage your Songs directory
           directly from your browser.
         </p>
-
-        <SupportedBrowserWarning />
       </section>
       <section className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-2 gap-8">
         <Card className="flex flex-col justify-between">
@@ -80,9 +77,9 @@ export default function Home() {
           </CardHeader>
           <CardFooter className="grid gap-4 py-4">
             <Link
-              href="#" // /spotify
-              className={buttonVariants({variant: 'ghost'})}>
-              Under Construction
+              href="/spotify" // /spotify
+              className={buttonVariants({variant: 'default'})}>
+              Go to Tool
             </Link>
           </CardFooter>
         </Card>

--- a/spotify-clonehero-next/app/spotify/AllSongsTab.tsx
+++ b/spotify-clonehero-next/app/spotify/AllSongsTab.tsx
@@ -1,0 +1,904 @@
+'use client';
+
+import {useCallback, useState, useEffect, useMemo} from 'react';
+import {Button} from '@/components/ui/button';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
+import {Input} from '@/components/ui/input';
+import {Label} from '@/components/ui/label';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from '@/components/ui/collapsible';
+import {ChevronDown, ChevronLeft, ChevronRight} from 'lucide-react';
+import {toast} from 'sonner';
+import {Searcher} from 'fast-fuzzy';
+
+import {useSpotifyTracks} from '@/lib/spotify-sdk/SpotifyFetching';
+import {
+  SongAccumulator,
+  createIsInstalledFilter,
+} from '@/lib/local-songs-folder/scanLocalCharts';
+import {scanForInstalledChartsCompat, canScanCharts} from '@/lib/local-songs-folder/index-compat';
+import {detectBrowserCapabilities} from '@/lib/browser-compat/FileSystemCompat';
+import chorusChartDb, {
+  findMatchingCharts,
+} from '@/lib/chorusChartDb';
+import SpotifyTableDownloader, {
+  SpotifyChartData,
+  SpotifyPlaysRecommendations,
+} from '../SpotifyTableDownloader';
+import {ChartResponseEncore} from '@/lib/chartSelection';
+import {RENDERED_INSTRUMENTS, AllowedInstrument, InstrumentImage, preFilterInstruments} from '@/components/ChartInstruments';
+
+type Status = {
+  status:
+    | 'not-started'
+    | 'scanning'
+    | 'done-scanning'
+    | 'fetching-spotify-data'
+    | 'songs-from-encore'
+    | 'finding-matches'
+    | 'done';
+  songsCounted: number;
+};
+
+type Falsy = false | 0 | '' | null | undefined;
+const _Boolean = <T extends any>(v: T): v is Exclude<typeof v, Falsy> =>
+  Boolean(v);
+
+export default function AllSongsTab() {
+  const [tracks, updateFromSpotify] = useSpotifyTracks();
+  const [songs, setSongs] = useState<SpotifyPlaysRecommendations[] | null>(null);
+  const [filteredSongs, setFilteredSongs] = useState<SpotifyPlaysRecommendations[] | null>(null);
+  const capabilities = detectBrowserCapabilities();
+  
+  const [status, setStatus] = useState<Status>({
+    status: 'not-started',
+    songsCounted: 0,
+  });
+
+  // Search and filter states
+  const [searchTerm, setSearchTerm] = useState('');
+  const [artistFilter, setArtistFilter] = useState('');
+  const [songFilter, setSongFilter] = useState('');
+  
+  // Instrument filter state
+  const [instrumentFilters, setInstrumentFilters] = useState<AllowedInstrument[]>([]);
+  
+  // Sorting states
+  const [sortBy, setSortBy] = useState<'artist' | 'song' | 'none'>('none');
+  const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>('asc');
+  
+  // Pagination states
+  const [currentPage, setCurrentPage] = useState(1);
+  const [songsPerPage, setSongsPerPage] = useState(100); // Show 100 songs per page for better performance
+  
+  // UI states
+  const [songFilterOpen, setSongFilterOpen] = useState(true);
+
+  // Auto-load all songs in fallback mode with efficient chart matching and ensure playlists are loaded
+  useEffect(() => {
+    // Always try to update from Spotify if we don't have tracks yet
+    if (tracks.length === 0) {
+      updateFromSpotify();
+    }
+
+    // Auto-run skip logic for fallback browsers
+    const autoLoadForFallback = async () => {
+      if (capabilities.mode === 'fallback' && tracks.length > 0 && !songs) {
+        // Run the skip directory selection logic automatically
+        try {
+          setStatus({ status: 'songs-from-encore', songsCounted: 0 });
+          
+          const fetchDb = chorusChartDb();
+          const allChorusCharts = await fetchDb;
+          
+          // Mark all charts as not installed since we're in fallback mode
+          const markedCharts = allChorusCharts.map((chart): SpotifyChartData => ({
+            ...chart,
+            isInstalled: false, // All charts are not installed in fallback mode
+          }));
+          
+          setStatus({ status: 'finding-matches', songsCounted: 0 });
+          
+          const artistSearcher = new Searcher(markedCharts, {
+            keySelector: chart => chart.artist,
+            threshold: 1,
+            useDamerau: false,
+            useSellers: false,
+          });
+
+          const allSongsWithCharts = tracks
+            .map(track => {
+              const artist = track.artists[0] || 'Unknown Artist';
+              const matchingCharts = findMatchingCharts(artist, track.name, artistSearcher);
+              
+              return {
+                artist,
+                song: track.name,
+                spotifyUrl: track.spotify_url,
+                previewUrl: track.preview_url,
+                playCount: track.playCount, // Preserve playCount if it exists
+                matchingCharts, // Include all matching charts
+              };
+            })
+            .filter(song => song.matchingCharts.length > 0); // Only show songs with matching charts
+          
+          setSongs(allSongsWithCharts);
+          setFilteredSongs(allSongsWithCharts);
+          setStatus({ status: 'done', songsCounted: 0 });
+          toast.success(`Loaded ${allSongsWithCharts.length} songs with chart matching (fallback mode)`);
+          
+        } catch (error) {
+          console.error('Error loading chart data in fallback mode:', error);
+          toast.error('Failed to load chart data in fallback mode');
+          
+          // Fallback to no charts if chart loading fails
+          const allSongsForDownload = tracks.map(track => ({
+            artist: track.artists[0] || 'Unknown Artist',
+            song: track.name,
+            spotifyUrl: track.spotify_url,
+            previewUrl: track.preview_url,
+            playCount: track.playCount, // Preserve playCount if it exists
+            matchingCharts: [] as SpotifyChartData[],
+          }));
+          
+          setSongs(allSongsForDownload);
+          setFilteredSongs(allSongsForDownload);
+          setStatus({ status: 'done', songsCounted: 0 });
+          toast.success(`Loaded ${allSongsForDownload.length} songs for download (chart matching failed)`);
+        }
+      }
+    };
+
+    autoLoadForFallback();
+  }, [capabilities.mode, tracks, songs, updateFromSpotify]);
+
+  const calculate = useCallback(async () => {
+    if (tracks.length === 0) {
+      toast.info('No tracks loaded from playlists. Loading all playlists may take a moment...');
+      return;
+    }
+
+    // In fallback mode, skip chart scanning and show all songs for download
+    if (capabilities.mode === 'fallback') {
+      // Use the same logic as skipDirectorySelection but with a different message
+      try {
+        setStatus({ status: 'songs-from-encore', songsCounted: 0 });
+        
+        const fetchDb = chorusChartDb();
+        const allChorusCharts = await fetchDb;
+        
+        // Mark all charts as not installed since we're in fallback mode
+        const markedCharts = allChorusCharts.map((chart): SpotifyChartData => ({
+          ...chart,
+          isInstalled: false, // All charts are not installed in fallback mode
+        }));
+        
+        setStatus({ status: 'finding-matches', songsCounted: 0 });
+        
+        const artistSearcher = new Searcher(markedCharts, {
+          keySelector: chart => chart.artist,
+          threshold: 1,
+          useDamerau: false,
+          useSellers: false,
+        });
+
+        const allSongsWithCharts = tracks
+          .map(track => {
+            const artist = track.artists[0] || 'Unknown Artist';
+            const matchingCharts = findMatchingCharts(artist, track.name, artistSearcher);
+            
+            return {
+              artist,
+              song: track.name,
+              spotifyUrl: track.spotify_url,
+              previewUrl: track.preview_url,
+              playCount: track.playCount, // Preserve playCount if it exists
+              matchingCharts, // Include all matching charts
+            };
+          })
+          .filter(song => song.matchingCharts.length > 0); // Only show songs with matching charts
+        
+        setSongs(allSongsWithCharts);
+        setFilteredSongs(allSongsWithCharts);
+        setStatus({ status: 'done', songsCounted: 0 });
+        toast.success(`Loaded ${allSongsWithCharts.length} songs with chart matching (fallback mode)`);
+        
+      } catch (error) {
+        console.error('Error loading chart data in fallback mode:', error);
+        toast.error('Failed to load chart data in fallback mode');
+        
+        // Fallback to no charts if chart loading fails
+        const allSongsForDownload = tracks.map(track => ({
+          artist: track.artists[0] || 'Unknown Artist',
+          song: track.name,
+          spotifyUrl: track.spotify_url,
+          previewUrl: track.preview_url,
+          playCount: track.playCount, // Preserve playCount if it exists
+          matchingCharts: [] as SpotifyChartData[],
+        }));
+        
+        setSongs(allSongsForDownload);
+        setFilteredSongs(allSongsForDownload);
+        setStatus({ status: 'done', songsCounted: 0 });
+        toast.success(`Loaded ${allSongsForDownload.length} songs for download (chart matching failed)`);
+      }
+      return;
+    }
+
+    if (!canScanCharts()) {
+      toast.error('Chart scanning is not supported in your browser. Please use Chrome, Edge, or Opera for full functionality.');
+      return;
+    }
+
+    const fetchDb = chorusChartDb();
+    let installedCharts: SongAccumulator[] | undefined;
+
+    try {
+      setStatus({
+        status: 'scanning',
+        songsCounted: 0,
+      });
+
+      const scanResult = await scanForInstalledChartsCompat(() => {
+        setStatus(prevStatus => ({
+          ...prevStatus,
+          songsCounted: prevStatus.songsCounted + 1,
+        }));
+      });
+      installedCharts = scanResult.installedCharts;
+      
+      // Show different message based on scanning mode
+      if (scanResult.mode === 'fallback') {
+        toast.success(`Scanned ${installedCharts.length} charts using fallback mode`);
+      } else {
+        toast.success(`Scanned ${installedCharts.length} charts`);
+      }
+      
+      setStatus(prevStatus => ({
+        ...prevStatus,
+        status: 'done-scanning',
+      }));
+      
+      await pause();
+    } catch (err) {
+      if (err instanceof Error && err.message == 'User canceled picker') {
+        toast.info('Directory picker canceled');
+        setStatus({
+          status: 'not-started',
+          songsCounted: 0,
+        });
+        return;
+      } else {
+        const errorMsg = err instanceof Error ? err.message : 'Unknown error';
+        toast.error(`Error scanning local charts: ${errorMsg}`, {duration: 8000});
+        setStatus({
+          status: 'not-started',
+          songsCounted: 0,
+        });
+        throw err;
+      }
+    }
+
+    const isInstalled = await createIsInstalledFilter(installedCharts);
+    setStatus(prevStatus => ({
+      ...prevStatus,
+      status: 'songs-from-encore',
+    }));
+    const allChorusCharts = await fetchDb;
+    const markedCharts = markInstalledCharts(allChorusCharts, isInstalled);
+
+    setStatus(prevStatus => ({
+      ...prevStatus,
+      status: 'finding-matches',
+    }));
+    
+    const artistSearcher = new Searcher(markedCharts, {
+      keySelector: chart => chart.artist,
+      threshold: 1,
+      useDamerau: false,
+      useSellers: false,
+    });
+
+    const recommendedCharts = tracks
+      .map(({name, artists, spotify_url, preview_url}) => {
+        const artist = artists[0];
+
+        const matchingCharts = findMatchingCharts(artist, name, artistSearcher);
+
+        if (
+          matchingCharts.length == 0 ||
+          !matchingCharts.some(chart => !chart.isInstalled)
+        ) {
+          return null;
+        }
+
+        return {
+          artist,
+          song: name,
+          spotifyUrl: spotify_url,
+          previewUrl: preview_url,
+          matchingCharts,
+        };
+      })
+      .filter(_Boolean);
+
+    setStatus(prevStatus => ({
+      ...prevStatus,
+      status: 'done',
+    }));
+
+    if (recommendedCharts.length > 0) {
+      setSongs(recommendedCharts);
+      setFilteredSongs(recommendedCharts);
+      console.log(recommendedCharts);
+    }
+  }, [tracks, capabilities.mode]);
+
+  // Apply filters with debouncing for performance
+  const applyFilters = useCallback(() => {
+    if (!songs) return;
+
+    let filtered = songs;
+
+    // General search term (searches both artist and song)
+    if (searchTerm) {
+      const lowercaseSearch = searchTerm.toLowerCase();
+      filtered = filtered.filter(
+        song =>
+          song.artist.toLowerCase().includes(lowercaseSearch) ||
+          song.song.toLowerCase().includes(lowercaseSearch)
+      );
+    }
+
+    // Specific artist filter
+    if (artistFilter) {
+      const lowercaseArtist = artistFilter.toLowerCase();
+      filtered = filtered.filter(song =>
+        song.artist.toLowerCase().includes(lowercaseArtist)
+      );
+    }
+
+    // Specific song filter
+    if (songFilter) {
+      const lowercaseSong = songFilter.toLowerCase();
+      filtered = filtered.filter(song =>
+        song.song.toLowerCase().includes(lowercaseSong)
+      );
+    }
+
+    // Instrument filter - matches SpotifyTableDownloader logic
+    if (instrumentFilters.length > 0) {
+      filtered = filtered.filter(song => {
+        // If no matching charts, don't show in instrument filter
+        if (!song.matchingCharts || song.matchingCharts.length === 0) {
+          return false;
+        }
+        
+        // Check if any chart has ALL the required instruments (matches SpotifyTableDownloader)
+        return song.matchingCharts.some(chart => {
+          const chartInstruments = preFilterInstruments(chart)
+          if (!chartInstruments) {
+            return false;
+          }
+          return instrumentFilters.every(instrument => 
+            Object.keys(chartInstruments).includes(instrument)
+          );
+        });
+      });
+    }
+
+    // Apply sorting
+    if (sortBy !== 'none') {
+      filtered.sort((a, b) => {
+        let comparison = 0;
+        if (sortBy === 'artist') {
+          comparison = a.artist.localeCompare(b.artist);
+        } else if (sortBy === 'song') {
+          comparison = a.song.localeCompare(b.song);
+        }
+        return sortOrder === 'desc' ? -comparison : comparison;
+      });
+    }
+
+    setFilteredSongs(filtered);
+    // Reset to first page when filters change
+    setCurrentPage(1);
+  }, [songs, searchTerm, artistFilter, songFilter, instrumentFilters, sortBy, sortOrder]);
+
+  // Paginated songs for display
+  const paginatedSongs = useMemo(() => {
+    if (!filteredSongs) return null;
+    
+    const startIndex = (currentPage - 1) * songsPerPage;
+    const endIndex = startIndex + songsPerPage;
+    return filteredSongs.slice(startIndex, endIndex);
+  }, [filteredSongs, currentPage, songsPerPage]);
+
+  const totalPages = filteredSongs ? Math.ceil(filteredSongs.length / songsPerPage) : 0;
+
+  // Debounced filtering to improve performance
+  useEffect(() => {
+    const timeoutId = setTimeout(() => {
+      applyFilters();
+    }, 150); // 150ms debounce
+
+    return () => clearTimeout(timeoutId);
+  }, [applyFilters]);
+
+  // Skip handler for supported browsers - show all songs with chart matching but no installed filtering
+  const skipDirectorySelection = useCallback(async () => {
+    if (tracks.length === 0) {
+      toast.info('No tracks loaded from playlists. Loading all playlists may take a moment...');
+      return;
+    }
+
+    try {
+      setStatus({ status: 'songs-from-encore', songsCounted: 0 });
+      
+      const fetchDb = chorusChartDb();
+      const allChorusCharts = await fetchDb;
+      
+      // In fallback mode, mark all charts as not installed
+      // In supported mode, also mark as not installed since we're skipping directory scan
+      const markedCharts = allChorusCharts.map((chart): SpotifyChartData => ({
+        ...chart,
+        isInstalled: false, // All charts are not installed when skipping
+      }));
+      
+      setStatus({ status: 'finding-matches', songsCounted: 0 });
+      
+      const artistSearcher = new Searcher(markedCharts, {
+        keySelector: chart => chart.artist,
+        threshold: 1,
+        useDamerau: false,
+        useSellers: false,
+      });
+
+      const allSongsWithCharts = tracks
+        .map(track => {
+          const artist = track.artists[0] || 'Unknown Artist';
+          const matchingCharts = findMatchingCharts(artist, track.name, artistSearcher);
+          
+          return {
+            artist,
+            song: track.name,
+            spotifyUrl: track.spotify_url,
+            previewUrl: track.preview_url,
+            playCount: track.playCount, // Preserve playCount if it exists
+            matchingCharts, // Include all matching charts
+          };
+        })
+        .filter(song => song.matchingCharts.length > 0); // Only show songs with matching charts
+      
+      setSongs(allSongsWithCharts);
+      setFilteredSongs(allSongsWithCharts);
+      setStatus({ status: 'done', songsCounted: 0 });
+      toast.success(`Loaded ${allSongsWithCharts.length} songs with chart matching`);
+      
+    } catch (error) {
+      console.error('Error loading chart data:', error);
+      toast.error('Failed to load chart data');
+      
+      // Fallback to no charts if chart loading fails
+      const allSongsForDownload = tracks.map(track => ({
+        artist: track.artists[0] || 'Unknown Artist',
+        song: track.name,
+        spotifyUrl: track.spotify_url,
+        previewUrl: track.preview_url,
+        playCount: track.playCount, // Preserve playCount if it exists
+        matchingCharts: [] as SpotifyChartData[],
+      }));
+      
+      setSongs(allSongsForDownload);
+      setFilteredSongs(allSongsForDownload);
+      setStatus({ status: 'done', songsCounted: 0 });
+      toast.success(`Loaded ${allSongsForDownload.length} songs for download (chart matching failed)`);
+    }
+  }, [tracks]);
+
+  // Instrument filter toggle function
+  const toggleInstrumentFilter = useCallback((instrument: AllowedInstrument) => {
+    setInstrumentFilters(prev => 
+      prev.includes(instrument) 
+        ? prev.filter(i => i !== instrument)
+        : [...prev, instrument]
+    );
+  }, []);
+
+  return (
+    <div className="space-y-6">
+      <Card>
+        <CardHeader>
+          <CardTitle>All Songs Search</CardTitle>
+          <CardDescription>
+            Search through all your Spotify playlists to find songs with matching Clone Hero charts
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="flex justify-center">
+            {renderStatus(status, calculate, skipDirectorySelection)}
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Search and Filter Controls */}
+      {songs && (
+        <Card>
+          <Collapsible open={songFilterOpen} onOpenChange={setSongFilterOpen}>
+            <CardHeader>
+              <CollapsibleTrigger asChild>
+                <div className="flex items-center justify-between cursor-pointer hover:bg-muted/30 rounded p-2 -m-2">
+                  <div>
+                    <CardTitle>Search and Filter Songs</CardTitle>
+                    <CardDescription>
+                      Filter your results by artist, song name, or both
+                      {filteredSongs && (
+                        <span className="ml-2">
+                          ({filteredSongs.length} of {songs.length} songs found)
+                          {totalPages > 1 && (
+                            <span> • Page {currentPage} of {totalPages}</span>
+                          )}
+                        </span>
+                      )}
+                    </CardDescription>
+                  </div>
+                  <ChevronDown className={`h-4 w-4 transition-transform duration-200 ${songFilterOpen ? 'rotate-180' : ''}`} />
+                </div>
+              </CollapsibleTrigger>
+            </CardHeader>
+            <CollapsibleContent>
+              <CardContent className="space-y-4">
+                <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+                  <div className="space-y-2">
+                    <Label htmlFor="search-all">Search All</Label>
+                    <Input
+                      id="search-all"
+                      placeholder="Search artists and songs..."
+                      value={searchTerm}
+                      onChange={(e) => setSearchTerm(e.target.value)}
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <Label htmlFor="artist-filter">Filter by Artist</Label>
+                    <Input
+                      id="artist-filter"
+                      placeholder="Artist name..."
+                      value={artistFilter}
+                      onChange={(e) => setArtistFilter(e.target.value)}
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <Label htmlFor="song-filter">Filter by Song</Label>
+                    <Input
+                      id="song-filter"
+                      placeholder="Song name..."
+                      value={songFilter}
+                      onChange={(e) => setSongFilter(e.target.value)}
+                    />
+                  </div>
+                </div>
+                
+                {/* Instrument Filters */}
+                <div className="pt-4 border-t">
+                  <div className="space-y-3">
+                    <Label>Filter by Instruments</Label>
+                    <p className="text-sm text-muted-foreground">
+                      Select instruments that must be available in charts (shows songs that have charts with ALL selected instruments)
+                    </p>
+                    <div className="flex flex-wrap gap-2">
+                      {RENDERED_INSTRUMENTS.map((instrument: AllowedInstrument) => (
+                        <button
+                          key={instrument}
+                          onClick={() => toggleInstrumentFilter(instrument)}
+                          className={`flex items-center gap-2 px-3 py-2 rounded-md border transition-colors ${
+                            instrumentFilters.includes(instrument)
+                              ? 'bg-primary text-primary-foreground border-primary'
+                              : 'bg-background hover:bg-muted border-input'
+                          }`}
+                        >
+                          <InstrumentImage 
+                            instrument={instrument} 
+                            size="sm" 
+                            classNames="w-4 h-4"
+                          />
+                          <span className="text-sm capitalize">{instrument}</span>
+                        </button>
+                      ))}
+                    </div>
+                    {instrumentFilters.length > 0 && (
+                      <div className="text-sm text-muted-foreground">
+                        Filtering by: {instrumentFilters.map(i => i.charAt(0).toUpperCase() + i.slice(1)).join(', ')}
+                      </div>
+                    )}
+                  </div>
+                </div>
+                
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-4 pt-4 border-t">
+                  <div className="space-y-2">
+                    <Label htmlFor="sort-by">Sort By</Label>
+                    <Select value={sortBy} onValueChange={(value: 'artist' | 'song' | 'none') => setSortBy(value)}>
+                      <SelectTrigger id="sort-by">
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="none">No Sorting</SelectItem>
+                        <SelectItem value="artist">Artist</SelectItem>
+                        <SelectItem value="song">Song</SelectItem>
+                      </SelectContent>
+                    </Select>
+                  </div>
+                  <div className="space-y-2">
+                    <Label htmlFor="sort-order">Sort Order</Label>
+                    <Select value={sortOrder} onValueChange={(value: 'asc' | 'desc') => setSortOrder(value)} disabled={sortBy === 'none'}>
+                      <SelectTrigger id="sort-order">
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="asc">Ascending (A-Z)</SelectItem>
+                        <SelectItem value="desc">Descending (Z-A)</SelectItem>
+                      </SelectContent>
+                    </Select>
+                  </div>
+                </div>
+
+                {/* Quick filter buttons */}
+                <div className="flex flex-wrap gap-2 pt-4 border-t">
+                  <div className="text-sm font-medium">Quick Actions:</div>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => {
+                      setSearchTerm('');
+                      setArtistFilter('');
+                      setSongFilter('');
+                      setInstrumentFilters([]);
+                      setSortBy('none');
+                      setSortOrder('asc');
+                    }}
+                  >
+                    Clear All Filters
+                  </Button>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => {
+                      setSortBy('artist');
+                      setSortOrder('asc');
+                    }}
+                  >
+                    Sort by Artist A-Z
+                  </Button>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => {
+                      setSortBy('song');
+                      setSortOrder('asc');
+                    }}
+                  >
+                    Sort by Song A-Z
+                  </Button>
+                </div>
+              </CardContent>
+            </CollapsibleContent>
+          </Collapsible>
+        </Card>
+      )}
+
+      {paginatedSongs && (
+        <>
+          {/* Results info and per-page selector */}
+          <Card>
+            <CardContent className="p-4">
+              <div className="flex items-center justify-between">
+                <div className="flex items-center gap-4">
+                  <div className="text-sm text-muted-foreground">
+                    Showing {((currentPage - 1) * songsPerPage) + 1} to {Math.min(currentPage * songsPerPage, filteredSongs?.length || 0)} of {filteredSongs?.length || 0} songs
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <Label htmlFor="per-page" className="text-sm">Per page:</Label>
+                    <Select 
+                      value={songsPerPage.toString()} 
+                      onValueChange={(value) => {
+                        setSongsPerPage(Number(value));
+                        setCurrentPage(1); // Reset to first page
+                      }}
+                    >
+                      <SelectTrigger id="per-page" className="w-20">
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="25">25</SelectItem>
+                        <SelectItem value="50">50</SelectItem>
+                        <SelectItem value="100">100</SelectItem>
+                        <SelectItem value="200">200</SelectItem>
+                        <SelectItem value="500">500</SelectItem>
+                      </SelectContent>
+                    </Select>
+                  </div>
+                </div>
+                {totalPages > 1 && (
+                  <div className="flex items-center gap-2">
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={() => setCurrentPage(currentPage - 1)}
+                      disabled={currentPage === 1}
+                    >
+                      <ChevronLeft className="h-4 w-4 mr-1" />
+                      Previous
+                    </Button>
+                    
+                    <div className="flex items-center gap-1">
+                      {Array.from({ length: Math.min(totalPages, 5) }, (_, i) => {
+                        let pageNumber;
+                        if (totalPages <= 5) {
+                          pageNumber = i + 1;
+                        } else if (currentPage <= 3) {
+                          pageNumber = i + 1;
+                        } else if (currentPage >= totalPages - 2) {
+                          pageNumber = totalPages - 4 + i;
+                        } else {
+                          pageNumber = currentPage - 2 + i;
+                        }
+                        
+                        return (
+                          <Button
+                            key={pageNumber}
+                            variant={currentPage === pageNumber ? "default" : "outline"}
+                            size="sm"
+                            className="w-10"
+                            onClick={() => setCurrentPage(pageNumber)}
+                          >
+                            {pageNumber}
+                          </Button>
+                        );
+                      })}
+                    </div>
+                    
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={() => setCurrentPage(currentPage + 1)}
+                      disabled={currentPage === totalPages}
+                    >
+                      Next
+                      <ChevronRight className="h-4 w-4 ml-1" />
+                    </Button>
+                  </div>
+                )}
+              </div>
+            </CardContent>
+          </Card>
+
+          <SpotifyTableDownloader tracks={paginatedSongs} showPreview={true} />
+
+          {/* Pagination Controls - Bottom */}
+          {totalPages > 1 && (
+            <Card>
+              <CardContent className="p-4">
+                <div className="flex items-center justify-center gap-2">
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => setCurrentPage(currentPage - 1)}
+                    disabled={currentPage === 1}
+                  >
+                    <ChevronLeft className="h-4 w-4 mr-1" />
+                    Previous
+                  </Button>
+                  
+                  <div className="flex items-center gap-1">
+                    {Array.from({ length: Math.min(totalPages, 7) }, (_, i) => {
+                      let pageNumber;
+                      if (totalPages <= 7) {
+                        pageNumber = i + 1;
+                      } else if (currentPage <= 4) {
+                        pageNumber = i + 1;
+                      } else if (currentPage >= totalPages - 3) {
+                        pageNumber = totalPages - 6 + i;
+                      } else {
+                        pageNumber = currentPage - 3 + i;
+                      }
+                      
+                      return (
+                        <Button
+                          key={pageNumber}
+                          variant={currentPage === pageNumber ? "default" : "outline"}
+                          size="sm"
+                          className="w-10"
+                          onClick={() => setCurrentPage(pageNumber)}
+                        >
+                          {pageNumber}
+                        </Button>
+                      );
+                    })}
+                  </div>
+                  
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => setCurrentPage(currentPage + 1)}
+                    disabled={currentPage === totalPages}
+                  >
+                    Next
+                    <ChevronRight className="h-4 w-4 ml-1" />
+                  </Button>
+                </div>
+              </CardContent>
+            </Card>
+          )}
+        </>
+      )}
+    </div>
+  );
+}
+
+function renderStatus(status: Status, scanHandler: () => void, skipHandler: () => void) {
+  const capabilities = detectBrowserCapabilities();
+  
+  switch (status.status) {
+    case 'not-started':
+      return (
+        <div className="flex flex-col gap-2">
+          {capabilities.mode !== 'fallback' && (
+            <Button onClick={scanHandler}>Select Clone Hero Songs Folder</Button>
+          )}
+          <Button variant="outline" onClick={skipHandler} size="sm">
+            Show All Songs for Download
+          </Button>
+        </div>
+      );
+    case 'scanning':
+    case 'done-scanning':
+      return `${status.songsCounted} songs scanned`;
+    case 'fetching-spotify-data':
+      return 'Scanning your Spotify Library';
+    case 'songs-from-encore':
+      return 'Downloading songs from Encore';
+    case 'finding-matches':
+      return 'Checking for song matches';
+    case 'done':
+      return capabilities.mode !== 'fallback' ? (
+        <Button onClick={scanHandler}>Rescan</Button>
+      ) : (
+        <Button variant="outline" onClick={skipHandler} size="sm">
+          Refresh Songs
+        </Button>
+      );
+  }
+}
+
+function markInstalledCharts(
+  allCharts: ChartResponseEncore[],
+  isInstalled: (artist: string, song: string, charter: string) => boolean,
+): SpotifyChartData[] {
+  return allCharts.map(
+    (chart): SpotifyChartData => ({
+      ...chart,
+      isInstalled: isInstalled(chart.artist, chart.name, chart.charter),
+    }),
+  );
+}
+
+async function pause() {
+  await new Promise(resolve => {
+    setTimeout(resolve, 10);
+  });
+}

--- a/spotify-clonehero-next/app/spotify/PlaylistSelectorTab.tsx
+++ b/spotify-clonehero-next/app/spotify/PlaylistSelectorTab.tsx
@@ -1,0 +1,891 @@
+'use client';
+
+import {useCallback, useState, useEffect, useMemo} from 'react';
+import {Button} from '@/components/ui/button';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
+import {Input} from '@/components/ui/input';
+import {Label} from '@/components/ui/label';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from '@/components/ui/collapsible';
+import {ChevronDown, ChevronLeft, ChevronRight} from 'lucide-react';
+import {toast} from 'sonner';
+import {Searcher} from 'fast-fuzzy';
+
+import {useSpotifySdk} from '@/lib/spotify-sdk/ClientInstance';
+import {SimplifiedPlaylist, SpotifyApi} from '@spotify/web-api-ts-sdk';
+import {
+  SongAccumulator,
+  createIsInstalledFilter,
+} from '@/lib/local-songs-folder/scanLocalCharts';
+import {scanForInstalledChartsCompat, canScanCharts} from '@/lib/local-songs-folder/index-compat';
+import {detectBrowserCapabilities} from '@/lib/browser-compat/FileSystemCompat';
+import chorusChartDb, {
+  findMatchingCharts,
+} from '@/lib/chorusChartDb';
+import SpotifyTableDownloader, {
+  SpotifyChartData,
+  SpotifyPlaysRecommendations,
+} from '../SpotifyTableDownloader';
+import {ChartResponseEncore} from '@/lib/chartSelection';
+
+type TrackResult = {
+  name: string;
+  artists: string[];
+  preview_url: string | null;
+  spotify_url: string;
+};
+
+type Status = {
+  status:
+    | 'not-started'
+    | 'loading-playlists'
+    | 'selecting-playlist'
+    | 'loading-tracks'
+    | 'scanning'
+    | 'done-scanning'
+    | 'fetching-spotify-data'
+    | 'songs-from-encore'
+    | 'finding-matches'
+    | 'done';
+  songsCounted: number;
+};
+
+type Falsy = false | 0 | '' | null | undefined;
+const _Boolean = <T extends any>(v: T): v is Exclude<typeof v, Falsy> =>
+  Boolean(v);
+
+async function getAllPlaylists(sdk: SpotifyApi): Promise<SimplifiedPlaylist[]> {
+  const playlists: SimplifiedPlaylist[] = [];
+  const limit = 50;
+  let offset = 0;
+  let total = null;
+  do {
+    const lists = await sdk.currentUser.playlists.playlists(limit, offset);
+    if (total == null) {
+      total = lists.total;
+    }
+    playlists.push(...lists.items);
+    offset += limit;
+  } while (total == null || offset < total);
+
+  return playlists;
+}
+
+async function getPlaylistTracks(
+  sdk: SpotifyApi,
+  playlistId: string,
+): Promise<TrackResult[]> {
+  const tracks: TrackResult[] = [];
+  const limit = 50;
+  let offset = 0;
+  let total = null;
+
+  do {
+    try {
+      const items = await sdk.playlists.getPlaylistItems(
+        playlistId,
+        undefined,
+        'total,limit,items(track(type,artists(type,name),name,preview_url, external_urls(spotify)))',
+        limit,
+        offset,
+      );
+
+      if (total == null) {
+        total = items.total;
+      }
+      const filteredTracks = items.items
+        .filter(item => item.track?.type === 'track')
+        .map((item: any): TrackResult => {
+          return {
+            name: item.track.name,
+            artists: item.track.artists.map((artist: any) => artist.name),
+            preview_url: item.track.preview_url,
+            spotify_url: item.track.external_urls.spotify,
+          };
+        });
+
+      tracks.push(...filteredTracks);
+      offset += limit;
+    } catch (error: any) {
+      throw error;
+    }
+  } while (total == null || offset < total);
+
+  return tracks;
+}
+
+export default function PlaylistSelectorTab() {
+  const sdk = useSpotifySdk();
+  const [playlists, setPlaylists] = useState<SimplifiedPlaylist[]>([]);
+  const [selectedPlaylistId, setSelectedPlaylistId] = useState<string>('');
+  const [currentPlaylistTracks, setCurrentPlaylistTracks] = useState<TrackResult[]>([]);
+  const [songs, setSongs] = useState<SpotifyPlaysRecommendations[] | null>(null);
+  const [filteredSongs, setFilteredSongs] = useState<SpotifyPlaysRecommendations[] | null>(null);
+  const capabilities = detectBrowserCapabilities();
+  
+  const [status, setStatus] = useState<Status>({
+    status: 'not-started',
+    songsCounted: 0,
+  });
+
+  // Search and filter states
+  const [searchTerm, setSearchTerm] = useState('');
+  const [artistFilter, setArtistFilter] = useState('');
+  const [songFilter, setSongFilter] = useState('');
+  const [playlistSearchTerm, setPlaylistSearchTerm] = useState('');
+  
+  // Pagination states
+  const [currentPage, setCurrentPage] = useState(1);
+  const [playlistsPerPage] = useState(10);
+  
+  // UI states
+  const [songFilterOpen, setSongFilterOpen] = useState(true);
+
+  // Load playlists on component mount
+  useEffect(() => {
+    if (sdk && playlists.length === 0) {
+      setStatus({ status: 'loading-playlists', songsCounted: 0 });
+      getAllPlaylists(sdk)
+        .then(loadedPlaylists => {
+          setPlaylists(loadedPlaylists);
+          setStatus({ status: 'selecting-playlist', songsCounted: 0 });
+        })
+        .catch(error => {
+          console.error('Error loading playlists:', error);
+          toast.error('Failed to load playlists');
+          setStatus({ status: 'not-started', songsCounted: 0 });
+        });
+    }
+  }, [sdk, playlists.length]);
+
+  // Load tracks when playlist is selected
+  const loadPlaylistTracks = useCallback(async (playlistId: string) => {
+    if (!sdk || !playlistId) return;
+
+    setStatus({ status: 'loading-tracks', songsCounted: 0 });
+    try {
+      const tracks = await getPlaylistTracks(sdk, playlistId);
+      setCurrentPlaylistTracks(tracks);
+      
+      // In fallback mode, immediately show songs with chart matching
+      if (capabilities.mode === 'fallback') {
+        try {
+          setStatus({ status: 'songs-from-encore', songsCounted: 0 });
+          
+          const fetchDb = chorusChartDb();
+          const allChorusCharts = await fetchDb;
+          
+          // Mark all charts as not installed since we're in fallback mode
+          const markedCharts = allChorusCharts.map((chart): SpotifyChartData => ({
+            ...chart,
+            isInstalled: false, // All charts are not installed in fallback mode
+          }));
+          
+          setStatus({ status: 'finding-matches', songsCounted: 0 });
+          
+          const artistSearcher = new Searcher(markedCharts, {
+            keySelector: chart => chart.artist,
+            threshold: 1,
+            useDamerau: false,
+            useSellers: false,
+          });
+
+          const allSongsWithCharts = tracks
+            .map(track => {
+              const artist = track.artists[0] || 'Unknown Artist';
+              const matchingCharts = findMatchingCharts(artist, track.name, artistSearcher);
+              
+              // Only include songs that have matching charts
+              if (matchingCharts.length === 0) {
+                return null;
+              }
+              
+              return {
+                artist,
+                song: track.name,
+                spotifyUrl: track.spotify_url,
+                previewUrl: track.preview_url,
+                matchingCharts, // Include all matching charts
+              };
+            })
+            .filter(_Boolean); // Remove null values
+          
+          setSongs(allSongsWithCharts);
+          setFilteredSongs(allSongsWithCharts);
+          setStatus({ status: 'done', songsCounted: 0 });
+          toast.success(`Loaded ${allSongsWithCharts.length} songs from playlist with chart matching (fallback mode)`);
+        } catch (error) {
+          console.error('Error loading chart data in fallback mode:', error);
+          toast.error('Failed to load chart data in fallback mode');
+          
+          // Fallback to no charts if chart loading fails
+          const allSongsForDownload = tracks.map(track => ({
+            artist: track.artists[0] || 'Unknown Artist',
+            song: track.name,
+            spotifyUrl: track.spotify_url,
+            previewUrl: track.preview_url,
+            matchingCharts: [] as SpotifyChartData[],
+          }));
+          
+          setSongs(allSongsForDownload);
+          setFilteredSongs(allSongsForDownload);
+          setStatus({ status: 'done', songsCounted: 0 });
+          toast.success(`Loaded ${allSongsForDownload.length} songs from playlist (chart matching failed)`);
+        }
+      } else {
+        setStatus({ status: 'not-started', songsCounted: 0 });
+        toast.success(`Loaded ${tracks.length} tracks from playlist. Click "Select Clone Hero Songs Folder" to find matching charts.`);
+      }
+    } catch (error) {
+      console.error('Error loading playlist tracks:', error);
+      toast.error('Failed to load playlist tracks');
+      setStatus({ status: 'not-started', songsCounted: 0 });
+    }
+  }, [sdk, capabilities.mode]);
+
+  const calculate = useCallback(async () => {
+    if (currentPlaylistTracks.length === 0) {
+      toast.info('Please select a playlist first.');
+      return;
+    }
+
+    // In fallback mode, show songs with chart matching
+    if (capabilities.mode === 'fallback') {
+      try {
+        setStatus({ status: 'songs-from-encore', songsCounted: 0 });
+        
+        const fetchDb = chorusChartDb();
+        const allChorusCharts = await fetchDb;
+        
+        // Mark all charts as not installed since we're in fallback mode
+        const markedCharts = allChorusCharts.map((chart): SpotifyChartData => ({
+          ...chart,
+          isInstalled: false, // All charts are not installed in fallback mode
+        }));
+        
+        setStatus({ status: 'finding-matches', songsCounted: 0 });
+        
+        const artistSearcher = new Searcher(markedCharts, {
+          keySelector: chart => chart.artist,
+          threshold: 1,
+          useDamerau: false,
+          useSellers: false,
+        });
+
+        const allSongsWithCharts = currentPlaylistTracks
+          .map(track => {
+            const artist = track.artists[0] || 'Unknown Artist';
+            const matchingCharts = findMatchingCharts(artist, track.name, artistSearcher);
+            
+            // Only include songs that have matching charts
+            if (matchingCharts.length === 0) {
+              return null;
+            }
+            
+            return {
+              artist,
+              song: track.name,
+              spotifyUrl: track.spotify_url,
+              previewUrl: track.preview_url,
+              matchingCharts, // Include all matching charts
+            };
+          })
+          .filter(_Boolean); // Remove null values
+        
+        setSongs(allSongsWithCharts);
+        setFilteredSongs(allSongsWithCharts);
+        setStatus({ status: 'done', songsCounted: 0 });
+        toast.success(`Loaded ${allSongsWithCharts.length} songs from selected playlist with chart matching (fallback mode)`);
+      } catch (error) {
+        console.error('Error loading chart data in fallback mode:', error);
+        toast.error('Failed to load chart data in fallback mode');
+        
+        // Fallback to no charts if chart loading fails
+        const allSongsForDownload = currentPlaylistTracks.map(track => ({
+          artist: track.artists[0] || 'Unknown Artist',
+          song: track.name,
+          spotifyUrl: track.spotify_url,
+          previewUrl: track.preview_url,
+          matchingCharts: [] as SpotifyChartData[],
+        }));
+        
+        setSongs(allSongsForDownload);
+        setFilteredSongs(allSongsForDownload);
+        setStatus({ status: 'done', songsCounted: 0 });
+        toast.success(`Loaded ${allSongsForDownload.length} songs from selected playlist (chart matching failed)`);
+      }
+      return;
+    }
+
+    if (!canScanCharts()) {
+      toast.error('Chart scanning is not supported in your browser. Please use Chrome, Edge, or Opera for full functionality.');
+      return;
+    }
+
+    const fetchDb = chorusChartDb();
+    let installedCharts: SongAccumulator[] | undefined;
+
+    try {
+      setStatus({
+        status: 'scanning',
+        songsCounted: 0,
+      });
+
+      const scanResult = await scanForInstalledChartsCompat(() => {
+        setStatus(prevStatus => ({
+          ...prevStatus,
+          songsCounted: prevStatus.songsCounted + 1,
+        }));
+      });
+      installedCharts = scanResult.installedCharts;
+      
+      if (scanResult.mode === 'fallback') {
+        toast.success(`Scanned ${installedCharts.length} charts using fallback mode`);
+      } else {
+        toast.success(`Scanned ${installedCharts.length} charts`);
+      }
+      
+      setStatus(prevStatus => ({
+        ...prevStatus,
+        status: 'done-scanning',
+      }));
+      
+      await pause();
+    } catch (err) {
+      if (err instanceof Error && err.message == 'User canceled picker') {
+        toast.info('Directory picker canceled');
+        setStatus({
+          status: 'not-started',
+          songsCounted: 0,
+        });
+        return;
+      } else {
+        const errorMsg = err instanceof Error ? err.message : 'Unknown error';
+        toast.error(`Error scanning local charts: ${errorMsg}`, {duration: 8000});
+        setStatus({
+          status: 'not-started',
+          songsCounted: 0,
+        });
+        throw err;
+      }
+    }
+
+    const isInstalled = await createIsInstalledFilter(installedCharts);
+    setStatus(prevStatus => ({
+      ...prevStatus,
+      status: 'songs-from-encore',
+    }));
+    const allChorusCharts = await fetchDb;
+    const markedCharts = markInstalledCharts(allChorusCharts, isInstalled);
+
+    setStatus(prevStatus => ({
+      ...prevStatus,
+      status: 'finding-matches',
+    }));
+    
+    const artistSearcher = new Searcher(markedCharts, {
+      keySelector: chart => chart.artist,
+      threshold: 1,
+      useDamerau: false,
+      useSellers: false,
+    });
+
+    const recommendedCharts = currentPlaylistTracks
+      .map(({name, artists, spotify_url, preview_url}) => {
+        const artist = artists[0];
+
+        const matchingCharts = findMatchingCharts(artist, name, artistSearcher);
+
+        // Only include songs that have matching charts
+        if (matchingCharts.length == 0) {
+          return null;
+        }
+
+        return {
+          artist,
+          song: name,
+          spotifyUrl: spotify_url,
+          previewUrl: preview_url,
+          matchingCharts,
+        };
+      })
+      .filter(_Boolean);
+
+    setStatus(prevStatus => ({
+      ...prevStatus,
+      status: 'done',
+    }));
+
+    if (recommendedCharts.length > 0) {
+      setSongs(recommendedCharts);
+      setFilteredSongs(recommendedCharts);
+      console.log(recommendedCharts);
+    } else {
+      toast.info('No matching charts found for the selected playlist');
+    }
+  }, [currentPlaylistTracks, capabilities.mode]);
+
+  // Apply filters with debouncing for performance
+  const applyFilters = useCallback(() => {
+    if (!songs) return;
+
+    let filtered = songs;
+
+    // General search term (searches both artist and song)
+    if (searchTerm) {
+      const lowercaseSearch = searchTerm.toLowerCase();
+      filtered = filtered.filter(
+        song =>
+          song.artist.toLowerCase().includes(lowercaseSearch) ||
+          song.song.toLowerCase().includes(lowercaseSearch)
+      );
+    }
+
+    // Specific artist filter
+    if (artistFilter) {
+      const lowercaseArtist = artistFilter.toLowerCase();
+      filtered = filtered.filter(song =>
+        song.artist.toLowerCase().includes(lowercaseArtist)
+      );
+    }
+
+    // Specific song filter
+    if (songFilter) {
+      const lowercaseSong = songFilter.toLowerCase();
+      filtered = filtered.filter(song =>
+        song.song.toLowerCase().includes(lowercaseSong)
+      );
+    }
+
+    setFilteredSongs(filtered);
+  }, [songs, searchTerm, artistFilter, songFilter]);
+
+  // Debounced filtering to improve performance
+  useEffect(() => {
+    const timeoutId = setTimeout(() => {
+      applyFilters();
+    }, 150); // 150ms debounce
+
+    return () => clearTimeout(timeoutId);
+  }, [applyFilters]);
+
+  // Skip handler for supported browsers - show songs with chart matching but no installed filtering
+  const skipDirectorySelection = useCallback(async () => {
+    if (currentPlaylistTracks.length === 0) {
+      toast.info('Please select a playlist first.');
+      return;
+    }
+
+    try {
+      setStatus({ status: 'songs-from-encore', songsCounted: 0 });
+      
+      const fetchDb = chorusChartDb();
+      const allChorusCharts = await fetchDb;
+      
+      // Mark all charts as not installed since we're skipping directory scan
+      const markedCharts = allChorusCharts.map((chart): SpotifyChartData => ({
+        ...chart,
+        isInstalled: false, // All charts are not installed when skipping
+      }));
+      
+      setStatus({ status: 'finding-matches', songsCounted: 0 });
+      
+      const artistSearcher = new Searcher(markedCharts, {
+        keySelector: chart => chart.artist,
+        threshold: 1,
+        useDamerau: false,
+        useSellers: false,
+      });
+
+      const allSongsWithCharts = currentPlaylistTracks
+        .map(track => {
+          const artist = track.artists[0] || 'Unknown Artist';
+          const matchingCharts = findMatchingCharts(artist, track.name, artistSearcher);
+          
+          // Only include songs that have matching charts
+          if (matchingCharts.length === 0) {
+            return null;
+          }
+          
+          return {
+            artist,
+            song: track.name,
+            spotifyUrl: track.spotify_url,
+            previewUrl: track.preview_url,
+            matchingCharts, // Include all matching charts
+          };
+        })
+        .filter(_Boolean); // Remove null values
+      
+      setSongs(allSongsWithCharts);
+      setFilteredSongs(allSongsWithCharts);
+      setStatus({ status: 'done', songsCounted: 0 });
+      toast.success(`Loaded ${allSongsWithCharts.length} songs from playlist with chart matching (directory scan skipped)`);
+      
+    } catch (error) {
+      console.error('Error loading chart data:', error);
+      toast.error('Failed to load chart data');
+      
+      // Fallback to no charts if chart loading fails
+      const allSongsForDownload = currentPlaylistTracks.map(track => ({
+        artist: track.artists[0] || 'Unknown Artist',
+        song: track.name,
+        spotifyUrl: track.spotify_url,
+        previewUrl: track.preview_url,
+        matchingCharts: [] as SpotifyChartData[],
+      }));
+      
+      setSongs(allSongsForDownload);
+      setFilteredSongs(allSongsForDownload);
+      setStatus({ status: 'done', songsCounted: 0 });
+      toast.success(`Loaded ${allSongsForDownload.length} songs from playlist (chart matching failed)`);
+    }
+  }, [currentPlaylistTracks]);
+
+  const selectedPlaylist = playlists.find(p => p.id === selectedPlaylistId);
+
+  // Filter playlists based on search term
+  const filteredPlaylists = useMemo(() => {
+    if (!playlistSearchTerm) return playlists;
+    
+    const lowercaseSearch = playlistSearchTerm.toLowerCase();
+    return playlists.filter(playlist =>
+      playlist.name.toLowerCase().includes(lowercaseSearch) ||
+      playlist.description?.toLowerCase().includes(lowercaseSearch) ||
+      playlist.owner.display_name?.toLowerCase().includes(lowercaseSearch)
+    );
+  }, [playlists, playlistSearchTerm]);
+
+  // Paginated playlists
+  const paginatedPlaylists = useMemo(() => {
+    const startIndex = (currentPage - 1) * playlistsPerPage;
+    const endIndex = startIndex + playlistsPerPage;
+    return filteredPlaylists.slice(startIndex, endIndex);
+  }, [filteredPlaylists, currentPage, playlistsPerPage]);
+
+  const totalPages = Math.ceil(filteredPlaylists.length / playlistsPerPage);
+
+  // Reset to first page when search changes
+  useEffect(() => {
+    setCurrentPage(1);
+  }, [playlistSearchTerm]);
+
+  return (
+    <div className="space-y-6">
+      {/* Playlist Selection */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Select Playlist</CardTitle>
+          <CardDescription>
+            Choose a single playlist to view and download its songs
+            {selectedPlaylist && (
+              <span className="ml-2">({currentPlaylistTracks.length} tracks loaded)</span>
+            )}
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          {status.status === 'loading-playlists' ? (
+            <p className="text-sm text-muted-foreground">Loading your playlists...</p>
+          ) : (
+            <div className="space-y-4">
+              <div className="space-y-2">
+                <Label htmlFor="playlist-search">Search Playlists</Label>
+                <Input
+                  id="playlist-search"
+                  placeholder="Search by playlist name, description, or owner..."
+                  value={playlistSearchTerm}
+                  onChange={(e) => setPlaylistSearchTerm(e.target.value)}
+                />
+              </div>
+
+              {/* Results and pagination info */}
+              <div className="flex items-center justify-between text-sm text-muted-foreground">
+                <span>
+                  {filteredPlaylists.length === 0 
+                    ? 'No playlists found'
+                    : `${filteredPlaylists.length} playlist${filteredPlaylists.length === 1 ? '' : 's'} found`
+                  }
+                </span>
+                {totalPages > 1 && (
+                  <span>
+                    Page {currentPage} of {totalPages}
+                  </span>
+                )}
+              </div>
+
+              {/* Playlist List */}
+              {filteredPlaylists.length === 0 ? (
+                <div className="text-center py-8 text-muted-foreground">
+                  {playlistSearchTerm 
+                    ? `No playlists found matching "${playlistSearchTerm}"`
+                    : 'No playlists available'
+                  }
+                </div>
+              ) : (
+                <div className="space-y-2">
+                  {paginatedPlaylists.map((playlist, index) => {
+                    const isSelected = selectedPlaylistId === playlist.id;
+                    return (
+                      <Card 
+                        key={`${playlist.id}-${index}`} 
+                        className={`cursor-pointer transition-colors hover:bg-muted/50 ${
+                          isSelected ? 'ring-2 ring-primary bg-muted/30' : ''
+                        }`}
+                        onClick={() => {
+                          setSelectedPlaylistId(playlist.id);
+                          loadPlaylistTracks(playlist.id);
+                          // Reset songs when changing playlist
+                          setSongs(null);
+                          setFilteredSongs(null);
+                        }}
+                      >
+                        <CardContent className="p-4">
+                          <div className="flex items-center space-x-4">
+                            {playlist.images?.[0] && (
+                              <img 
+                                src={playlist.images[0].url} 
+                                alt={playlist.name}
+                                className="w-16 h-16 rounded-lg object-cover flex-shrink-0"
+                              />
+                            )}
+                            <div className="flex-1 min-w-0">
+                              <div className="flex items-center gap-2">
+                                <h3 className="font-semibold text-lg truncate">{playlist.name}</h3>
+                                {isSelected && (
+                                  <span className="text-xs bg-primary text-primary-foreground px-2 py-1 rounded">
+                                    Selected
+                                  </span>
+                                )}
+                              </div>
+                              {playlist.description && (
+                                <p className="text-sm text-muted-foreground line-clamp-2 mt-1">
+                                  {playlist.description}
+                                </p>
+                              )}
+                              <div className="flex items-center gap-4 mt-2 text-sm text-muted-foreground">
+                                <span>{playlist.tracks.total} tracks</span>
+                                <span>by {playlist.owner.display_name || 'Unknown'}</span>
+                                {playlist.public !== undefined && (
+                                  <span>{playlist.public ? 'Public' : 'Private'}</span>
+                                )}
+                              </div>
+                            </div>
+                          </div>
+                        </CardContent>
+                      </Card>
+                    );
+                  })}
+                </div>
+              )}
+
+              {/* Pagination Controls */}
+              {totalPages > 1 && (
+                <div className="flex items-center justify-center gap-2 pt-4">
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => setCurrentPage(currentPage - 1)}
+                    disabled={currentPage === 1}
+                  >
+                    <ChevronLeft className="h-4 w-4 mr-1" />
+                    Previous
+                  </Button>
+                  
+                  <div className="flex items-center gap-1">
+                    {Array.from({ length: Math.min(totalPages, 5) }, (_, i) => {
+                      let pageNumber;
+                      if (totalPages <= 5) {
+                        pageNumber = i + 1;
+                      } else if (currentPage <= 3) {
+                        pageNumber = i + 1;
+                      } else if (currentPage >= totalPages - 2) {
+                        pageNumber = totalPages - 4 + i;
+                      } else {
+                        pageNumber = currentPage - 2 + i;
+                      }
+                      
+                      return (
+                        <Button
+                          key={pageNumber}
+                          variant={currentPage === pageNumber ? "default" : "outline"}
+                          size="sm"
+                          className="w-10"
+                          onClick={() => setCurrentPage(pageNumber)}
+                        >
+                          {pageNumber}
+                        </Button>
+                      );
+                    })}
+                  </div>
+                  
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => setCurrentPage(currentPage + 1)}
+                    disabled={currentPage === totalPages}
+                  >
+                    Next
+                    <ChevronRight className="h-4 w-4 ml-1" />
+                  </Button>
+                </div>
+              )}
+              
+              {status.status === 'loading-tracks' && (
+                <p className="text-sm text-muted-foreground text-center py-2">Loading playlist tracks...</p>
+              )}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Scan Button */}
+      {selectedPlaylistId && currentPlaylistTracks.length > 0 && (
+        <Card>
+          <CardHeader>
+            <CardTitle>
+              {capabilities.mode === 'fallback' ? 'Download from Selected Playlist' : 'Scan Selected Playlist'}
+            </CardTitle>
+            <CardDescription>
+              {capabilities.mode === 'fallback' 
+                ? `Download songs from "${selectedPlaylist?.name}" with matching Clone Hero charts`
+                : `Scan "${selectedPlaylist?.name}" (${currentPlaylistTracks.length} tracks) for matching Clone Hero charts`
+              }
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <div className="flex justify-center">
+              {capabilities.mode === 'fallback' 
+                ? (songs ? (
+                    <p className="text-sm text-muted-foreground">
+                      {songs.length} songs with matching charts loaded
+                    </p>
+                  ) : (
+                    <p className="text-sm text-muted-foreground">Loading songs with chart matching...</p>
+                  ))
+                : renderStatus(status, calculate, skipDirectorySelection)
+              }
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Search and Filter Controls */}
+      {songs && (
+        <Card>
+          <Collapsible open={songFilterOpen} onOpenChange={setSongFilterOpen}>
+            <CardHeader>
+              <CollapsibleTrigger asChild>
+                <div className="flex items-center justify-between cursor-pointer hover:bg-muted/30 rounded p-2 -m-2">
+                  <div>
+                    <CardTitle>Search and Filter Songs</CardTitle>
+                    <CardDescription>
+                      Filter your results by artist, song name, or both
+                      {filteredSongs && (
+                        <span className="ml-2">({filteredSongs.length} of {songs.length} songs)</span>
+                      )}
+                    </CardDescription>
+                  </div>
+                  <ChevronDown className={`h-4 w-4 transition-transform duration-200 ${songFilterOpen ? 'rotate-180' : ''}`} />
+                </div>
+              </CollapsibleTrigger>
+            </CardHeader>
+            <CollapsibleContent>
+              <CardContent className="space-y-4">
+                <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+                  <div className="space-y-2">
+                    <Label htmlFor="search-all">Search All</Label>
+                    <Input
+                      id="search-all"
+                      placeholder="Search artists and songs..."
+                      value={searchTerm}
+                      onChange={(e) => setSearchTerm(e.target.value)}
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <Label htmlFor="artist-filter">Filter by Artist</Label>
+                    <Input
+                      id="artist-filter"
+                      placeholder="Artist name..."
+                      value={artistFilter}
+                      onChange={(e) => setArtistFilter(e.target.value)}
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <Label htmlFor="song-filter">Filter by Song</Label>
+                    <Input
+                      id="song-filter"
+                      placeholder="Song name..."
+                      value={songFilter}
+                      onChange={(e) => setSongFilter(e.target.value)}
+                    />
+                  </div>
+                </div>
+              </CardContent>
+            </CollapsibleContent>
+          </Collapsible>
+        </Card>
+      )}
+
+      {filteredSongs && <SpotifyTableDownloader tracks={filteredSongs} showPreview={true} />}
+    </div>
+  );
+}
+
+function renderStatus(status: Status, scanHandler: () => void, skipHandler: () => void) {
+  switch (status.status) {
+    case 'not-started':
+      return (
+        <div className="flex flex-col gap-2">
+          <Button onClick={scanHandler}>Select Clone Hero Songs Folder</Button>
+          <Button variant="outline" onClick={skipHandler} size="sm">
+            Skip - Show All Songs for Download
+          </Button>
+        </div>
+      );
+    case 'scanning':
+    case 'done-scanning':
+      return `${status.songsCounted} songs scanned`;
+    case 'fetching-spotify-data':
+      return 'Scanning your Spotify Library';
+    case 'songs-from-encore':
+      return 'Downloading songs from Encore';
+    case 'finding-matches':
+      return 'Checking for song matches';
+    case 'done':
+      return <Button onClick={scanHandler}>Rescan</Button>;
+  }
+}
+
+function markInstalledCharts(
+  allCharts: ChartResponseEncore[],
+  isInstalled: (artist: string, song: string, charter: string) => boolean,
+): SpotifyChartData[] {
+  return allCharts.map(
+    (chart): SpotifyChartData => ({
+      ...chart,
+      isInstalled: isInstalled(chart.artist, chart.name, chart.charter),
+    }),
+  );
+}
+
+async function pause() {
+  await new Promise(resolve => {
+    setTimeout(resolve, 10);
+  });
+}

--- a/spotify-clonehero-next/app/spotify/Spotify.tsx
+++ b/spotify-clonehero-next/app/spotify/Spotify.tsx
@@ -1,281 +1,73 @@
 'use client';
 
-import {signIn, signOut, useSession} from 'next-auth/react';
-
-import {TrackResult, useSpotifyTracks} from '@/lib/spotify-sdk/SpotifyFetching';
-import {Button} from '@/components/ui/button';
-import {useCallback, useState} from 'react';
-import {
-  SongAccumulator,
-  createIsInstalledFilter,
-} from '@/lib/local-songs-folder/scanLocalCharts';
-import {scanForInstalledCharts} from '@/lib/local-songs-folder';
-import chorusChartDb, {
-  findMatchingCharts,
-  findMatchingChartsExact,
-} from '@/lib/chorusChartDb';
-import SpotifyTableDownloader, {
-  SpotifyChartData,
-  SpotifyPlaysRecommendations,
-} from '../SpotifyTableDownloader';
+import {useSession} from 'next-auth/react';
 import {
   Card,
-  CardContent,
   CardDescription,
   CardHeader,
   CardTitle,
 } from '@/components/ui/card';
-import {Icons} from '@/components/icons';
-import Image from 'next/image';
-import spotifyLogoBlack from '@/public/assets/spotify/logo_black.png';
-import spotifyLogoWhite from '@/public/assets/spotify/logo_white.png';
-import SupportedBrowserWarning from '../SupportedBrowserWarning';
-import {ChartResponseEncore} from '@/lib/chartSelection';
-import {Searcher} from 'fast-fuzzy';
-import {toast} from 'sonner';
+import {
+  Tabs,
+  TabsContent,
+  TabsList,
+  TabsTrigger,
+} from '@/components/ui/tabs';
 
-type Falsy = false | 0 | '' | null | undefined;
-const _Boolean = <T extends any>(v: T): v is Exclude<typeof v, Falsy> =>
-  Boolean(v);
-
-/* TODO:
-+ Add Spotify logos
-- Add progress messages for scanning
-- Make header prettier?
-+ Make table buttons match theme
-- List what Spotify Playlist the song is in
-- Make spotify logo light in dark mode
-*/
+// Import the individual tab components
+import AllSongsTab from './AllSongsTab';
+import PlaylistSelectorTab from './PlaylistSelectorTab';
 
 export default function Spotify() {
   const session = useSession();
 
-  if (!session || session.status !== 'authenticated') {
+  if (session.status === 'loading') {
     return (
-      <Card>
-        <CardHeader>
-          <CardTitle>Sign in with Spotify</CardTitle>
-          <CardDescription>
-            Sign in with your Spotify account for the tool to scan your
-            playlists and find matching charts on Chorus.
-          </CardDescription>
-        </CardHeader>
-        <CardContent className="space-y-4">
-          <Button onClick={() => signIn('spotify')} className="w-full">
-            <Icons.spotify className="h-4 w-4 mr-2" />
-            Sign in with Spotify
-          </Button>
-        </CardContent>
-      </Card>
+      <div className="flex items-center justify-center min-h-[50vh]">
+        <Card>
+          <CardHeader>
+            <CardTitle>Loading...</CardTitle>
+            <CardDescription>
+              Checking your authentication status...
+            </CardDescription>
+          </CardHeader>
+        </Card>
+      </div>
+    );
+  }
+
+  if (session.status !== 'authenticated') {
+    return (
+      <div className="flex items-center justify-center min-h-[50vh]">
+        <Card>
+          <CardHeader>
+            <CardTitle>Authentication Required</CardTitle>
+            <CardDescription>
+              Please sign in with your Spotify account using the button in the header to access these tools.
+            </CardDescription>
+          </CardHeader>
+        </Card>
+      </div>
     );
   }
 
   return (
-    <SupportedBrowserWarning>
-      <div className="w-full">
-        <div className="flex flex-col items-end px-6">
-          <h3 className="text-xl">
-            All data provided by
-            <Image
-              src={spotifyLogoBlack}
-              sizes="8em"
-              className="inline dark:hidden px-2"
-              priority={true}
-              style={{
-                width: 'auto',
-                height: 'auto',
-              }}
-              alt="Spotify"
-            />
-            <Image
-              src={spotifyLogoWhite}
-              sizes="8em"
-              className="dark:inline px-2"
-              priority={true}
-              style={{
-                width: 'auto',
-                height: 'auto',
-              }}
-              alt="Spotify"
-            />
-          </h3>
-          <Button onClick={() => signOut()}>Sign out</Button>
-        </div>
-        <LoggedIn />
-      </div>
-    </SupportedBrowserWarning>
+    <div className="container mx-auto px-4 py-6">
+      <Tabs defaultValue="playlists" className="w-full">
+        <TabsList className="grid w-full grid-cols-2">
+          <TabsTrigger value="playlists">Playlist Selector</TabsTrigger>
+          <TabsTrigger value="all-songs">All Songs Search</TabsTrigger>
+        </TabsList>
+        
+        <TabsContent value="all-songs" className="mt-6">
+          <AllSongsTab />
+        </TabsContent>
+        
+        <TabsContent value="playlists" className="mt-6">
+          <PlaylistSelectorTab />
+        </TabsContent>
+      </Tabs>
+    </div>
   );
 }
 
-type Status = {
-  status:
-    | 'not-started'
-    | 'scanning'
-    | 'done-scanning'
-    | 'fetching-spotify-data'
-    | 'songs-from-encore'
-    | 'finding-matches'
-    | 'done';
-  songsCounted: number;
-};
-
-function LoggedIn() {
-  const [tracks, update] = useSpotifyTracks();
-  const [songs, setSongs] = useState<SpotifyPlaysRecommendations[] | null>(
-    null,
-  );
-
-  const [status, setStatus] = useState<Status>({
-    status: 'not-started',
-    songsCounted: 0,
-  });
-
-  const [calculating, setCalculating] = useState(false);
-
-  const calculate = useCallback(async () => {
-    const fetchDb = chorusChartDb();
-
-    setCalculating(true);
-    const updatePromise = update();
-    let installedCharts: SongAccumulator[] | undefined;
-
-    try {
-      setStatus({
-        status: 'scanning',
-        songsCounted: 0,
-      });
-
-      const scanResult = await scanForInstalledCharts(() => {
-        setStatus(prevStatus => ({
-          ...prevStatus,
-          songsCounted: prevStatus.songsCounted + 1,
-        }));
-      });
-      installedCharts = scanResult.installedCharts;
-      setStatus(prevStatus => ({
-        ...prevStatus,
-        status: 'done-scanning',
-      }));
-      // Yield to React to let it update State
-      await pause();
-    } catch (err) {
-      if (err instanceof Error && err.message == 'User canceled picker') {
-        toast.info('Directory picker canceled');
-        setStatus({
-          status: 'not-started',
-          songsCounted: 0,
-        });
-        return;
-      } else {
-        toast.error('Error scanning local charts', {duration: 8000});
-        setStatus({
-          status: 'not-started',
-          songsCounted: 0,
-        });
-        throw err;
-      }
-    }
-
-    const isInstalled = await createIsInstalledFilter(installedCharts);
-    setStatus(prevStatus => ({
-      ...prevStatus,
-      status: 'songs-from-encore',
-    }));
-    const allChorusCharts = await fetchDb;
-    const markedCharts = markInstalledCharts(allChorusCharts, isInstalled);
-
-    setStatus(prevStatus => ({
-      ...prevStatus,
-      status: 'finding-matches',
-    }));
-    const artistSearcher = new Searcher(markedCharts, {
-      keySelector: chart => chart.artist,
-      threshold: 1,
-      useDamerau: false,
-      useSellers: false,
-    });
-
-    const recommendedCharts = tracks
-      .map(({name, artists, spotify_url, preview_url}) => {
-        const artist = artists[0];
-
-        const matchingCharts = findMatchingCharts(artist, name, artistSearcher);
-
-        if (
-          matchingCharts.length == 0 ||
-          !matchingCharts.some(chart => !chart.isInstalled)
-        ) {
-          return null;
-        }
-
-        return {
-          artist,
-          song: name,
-          spotifyUrl: spotify_url,
-          previewUrl: preview_url,
-          matchingCharts,
-        };
-      })
-      .filter(_Boolean);
-
-    setStatus(prevStatus => ({
-      ...prevStatus,
-      status: 'done',
-    }));
-
-    if (recommendedCharts.length > 0) {
-      setSongs(recommendedCharts);
-      console.log(recommendedCharts);
-    }
-    setCalculating(false);
-  }, [tracks, update]);
-
-  return (
-    <>
-      <div className="flex justify-center">
-        {renderStatus(status, calculate)}
-      </div>
-
-      {songs && <SpotifyTableDownloader tracks={songs} showPreview={true} />}
-    </>
-  );
-}
-
-function renderStatus(status: Status, scanHandler: () => void) {
-  switch (status.status) {
-    case 'not-started':
-      return (
-        <Button onClick={scanHandler}>Select Clone Hero Songs Folder</Button>
-      );
-    case 'scanning':
-    case 'done-scanning':
-      return `${status.songsCounted} songs scanned`;
-    case 'fetching-spotify-data':
-      return 'Scanning your Spotify Library';
-    case 'songs-from-encore':
-      return 'Downloading songs from Encore';
-    case 'finding-matches':
-      return 'Checking for song matches';
-    case 'done':
-      return <Button onClick={scanHandler}>Rescan</Button>;
-  }
-}
-
-function markInstalledCharts(
-  allCharts: ChartResponseEncore[],
-  isInstalled: (artist: string, song: string, charter: string) => boolean,
-): SpotifyChartData[] {
-  return allCharts.map(
-    (chart): SpotifyChartData => ({
-      ...chart,
-      isInstalled: isInstalled(chart.artist, chart.name, chart.charter),
-    }),
-  );
-}
-
-async function pause() {
-  // Yield to React to let it update State
-  await new Promise(resolve => {
-    setTimeout(resolve, 10);
-  });
-}

--- a/spotify-clonehero-next/app/spotifyhistory/SpotifyHistory.tsx
+++ b/spotify-clonehero-next/app/spotifyhistory/SpotifyHistory.tsx
@@ -53,20 +53,6 @@ export default function Page() {
   let auth = null;
   const session = useSession();
 
-  auth =
-    !session || session.status !== 'authenticated' ? (
-      <div>
-        <Button onClick={() => signIn('spotify')}>
-          Sign in with Spotify for Previews
-        </Button>
-      </div>
-    ) : (
-      <div className="space-y-4 sm:space-y-0 sm:space-x-4 w-full text-start sm:text-start">
-        <span>Logged in as {session.data.user?.name}</span>
-        <Button onClick={() => signOut()}>Sign out</Button>
-      </div>
-    );
-
   return (
     <>
       {auth}
@@ -82,9 +68,7 @@ export default function Page() {
         ever listened to.
       </p>
       <Suspense fallback={<div>Loading...</div>}>
-        <SupportedBrowserWarning>
-          <SpotifyHistory authenticated={session.status === 'authenticated'} />
-        </SupportedBrowserWarning>
+        <SpotifyHistory authenticated={session.status === 'authenticated'} />
       </Suspense>
     </>
   );

--- a/spotify-clonehero-next/components/ChartInstruments.tsx
+++ b/spotify-clonehero-next/components/ChartInstruments.tsx
@@ -1,5 +1,6 @@
 import {ChartResponseEncore} from '@/lib/chartSelection';
 import {memo, useCallback} from 'react';
+import Image from 'next/image';
 
 export const RENDERED_INSTRUMENTS = [
   'bass',
@@ -38,7 +39,7 @@ export const InstrumentImage = memo(function InstrumentImage({
     }
   }, [instrument, onClick]);
   return (
-    <img
+    <Image
       className={`inline-block ${classNames}`}
       key={instrument}
       alt={`Icon for instrument ${instrument}`}

--- a/spotify-clonehero-next/components/GlobalHeader.tsx
+++ b/spotify-clonehero-next/components/GlobalHeader.tsx
@@ -1,0 +1,274 @@
+'use client';
+
+import {signIn, signOut, useSession} from 'next-auth/react';
+import {useState, useEffect} from 'react';
+import {Button} from '@/components/ui/button';
+import {Icons} from '@/components/icons';
+import {detectBrowserCapabilities, type BrowserCapabilities} from '@/lib/browser-compat/FileSystemCompat';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog';
+import {Badge} from '@/components/ui/badge';
+import {Alert, AlertDescription, AlertTitle} from '@/components/ui/alert';
+import {AlertTriangle, Info, CheckCircle, XCircle} from 'lucide-react';
+import Link from 'next/link';
+import Image from 'next/image';
+import spotifyLogoBlack from '@/public/assets/spotify/logo_black.png';
+import spotifyLogoWhite from '@/public/assets/spotify/logo_white.png';
+
+export default function GlobalHeader() {
+  const session = useSession();
+  const [capabilities, setCapabilities] = useState<BrowserCapabilities | null>(null);
+  const [isCompatModalOpen, setIsCompatModalOpen] = useState(false);
+
+  // Detect browser capabilities on client side only to avoid hydration mismatch
+  useEffect(() => {
+    setCapabilities(detectBrowserCapabilities());
+  }, []);
+
+  const getBrowserName = (): string => {
+    if (typeof window === 'undefined') return 'Unknown';
+    
+    const userAgent = window.navigator.userAgent;
+    if (userAgent.includes('Chrome') && !userAgent.includes('Edg')) return 'Chrome';
+    if (userAgent.includes('Firefox')) return 'Firefox';
+    if (userAgent.includes('Safari') && !userAgent.includes('Chrome')) return 'Safari';
+    if (userAgent.includes('Edg')) return 'Edge';
+    if (userAgent.includes('Opera')) return 'Opera';
+    return 'Unknown';
+  };
+
+  const getCompatibilityMessage = () => {
+    if (!capabilities) return null;
+    
+    switch (capabilities.mode) {
+      case 'native':
+        return {
+          type: 'success' as const,
+          title: 'Full Compatibility',
+          description: 'Your browser supports all features including directory access and file downloads.',
+        };
+      case 'fallback':
+        return {
+          type: 'warning' as const,
+          title: 'Limited Compatibility',
+          description: 'Your browser supports most features with some limitations. File system access will use fallback methods.',
+        };
+      case 'unsupported':
+        return {
+          type: 'error' as const,
+          title: 'Unsupported Browser',
+          description: 'Your browser does not support the required file system APIs.',
+        };
+    }
+  };
+
+  const message = getCompatibilityMessage();
+
+  return (
+    <header className="border-b">
+      <div className="container mx-auto px-4 py-3 flex items-center justify-between">
+        {/* Left side - Logo/Brand */}
+        <div className="flex items-center space-x-4">
+          <Link href='/'>
+            <h1 className="text-xl font-bold">Music Chart Tools</h1>
+          </Link>
+          <div className="hidden md:flex items-center space-x-2">
+            <Button variant="ghost" size="icon" className="w-9 px-0" asChild>
+              <a
+                href="https://discord.gg/EDxu95B98s"
+                target="_blank"
+                rel="noreferrer">
+                <Icons.discord className="h-4 w-4" />
+                <span className="sr-only">Discord</span>
+              </a>
+            </Button>
+            <Button variant="ghost" size="icon" className="w-9 px-0" asChild>
+              <a
+                href="https://github.com/TheSavior/spotify-clonehero"
+                target="_blank"
+                rel="noreferrer">
+                <Icons.gitHub className="h-4 w-4" />
+                <span className="sr-only">GitHub</span>
+              </a>
+            </Button>
+          </div>
+        </div>
+
+        {/* Center - Spotify branding when authenticated */}
+        {session?.status === 'authenticated' && (
+          <div className="flex items-center text-sm text-muted-foreground">
+            <span>Powered by</span>
+            <Image
+              src={spotifyLogoBlack}
+              sizes="6em"
+              className="inline dark:hidden px-2"
+              priority={true}
+              style={{
+                width: 'auto',
+                height: 'auto',
+              }}
+              alt="Spotify"
+            />
+            <Image
+              src={spotifyLogoWhite}
+              sizes="6em"
+              className="dark:inline px-2"
+              priority={true}
+              style={{
+                width: 'auto',
+                height: 'auto',
+              }}
+              alt="Spotify"
+            />
+          </div>
+        )}
+
+        {/* Right side - Auth and compatibility */}
+        <div className="flex items-center space-x-2">
+          {/* Browser compatibility warning */}
+          {capabilities && capabilities.mode !== 'native' && (
+            <Dialog open={isCompatModalOpen} onOpenChange={setIsCompatModalOpen}>
+              <DialogTrigger asChild>
+                <Button 
+                  variant="outline" 
+                  size="sm"
+                  className={capabilities?.mode === 'fallback' ? 'text-yellow-600' : 'text-red-600'}
+                >
+                  <AlertTriangle className="h-4 w-4" />
+                </Button>
+              </DialogTrigger>
+              <DialogContent className="max-w-2xl">
+                <DialogHeader>
+                  <DialogTitle className="flex items-center gap-2">
+                    Browser Compatibility Status
+                    {capabilities?.mode === 'native' ? (
+                      <CheckCircle className="h-5 w-5 text-green-500" />
+                    ) : capabilities?.mode === 'fallback' ? (
+                      <AlertTriangle className="h-5 w-5 text-yellow-500" />
+                    ) : (
+                      <XCircle className="h-5 w-5 text-red-500" />
+                    )}
+                  </DialogTitle>
+                  <DialogDescription>
+                    Current browser: {getBrowserName()} • Mode: {capabilities?.mode || 'Loading...'}
+                  </DialogDescription>
+                </DialogHeader>
+
+                <div className="space-y-4">
+                  {capabilities && message && capabilities.mode !== 'native' && (
+                    <Alert variant={capabilities.mode === 'fallback' ? 'default' : 'destructive'}>
+                      {capabilities.mode === 'fallback' ? (
+                        <AlertTriangle className="h-4 w-4" />
+                      ) : (
+                        <XCircle className="h-4 w-4" />
+                      )}
+                      <AlertTitle>{message.title}</AlertTitle>
+                      <AlertDescription>
+                        {message.description}
+                      </AlertDescription>
+                    </Alert>
+                  )}
+
+                  {capabilities && (
+                    <div className="grid grid-cols-2 md:grid-cols-3 gap-4">
+                      <div className="flex items-center justify-between">
+                        <span className="text-sm">Directory Access</span>
+                        <Badge variant={capabilities.canReadDirectories ? 'default' : 'destructive'}>
+                          {capabilities.canReadDirectories ? 'Supported' : 'Not Supported'}
+                        </Badge>
+                      </div>
+                      
+                      <div className="flex items-center justify-between">
+                        <span className="text-sm">File Downloads</span>
+                        <Badge variant={capabilities.canDownloadFiles ? 'default' : 'destructive'}>
+                          {capabilities.canDownloadFiles ? 'Supported' : 'Not Supported'}
+                        </Badge>
+                      </div>
+                      
+                      <div className="flex items-center justify-between">
+                        <span className="text-sm">File Writing</span>
+                        <Badge variant={capabilities.canWriteFiles ? 'default' : 'secondary'}>
+                          {capabilities.canWriteFiles ? 'Native' : 'Download Only'}
+                        </Badge>
+                      </div>
+                      
+                      <div className="flex items-center justify-between">
+                        <span className="text-sm">Directory Picker</span>
+                        <Badge variant={capabilities.supportsDirectoryPicker ? 'default' : 'secondary'}>
+                          {capabilities.supportsDirectoryPicker ? 'Native' : 'Fallback'}
+                        </Badge>
+                      </div>
+                      
+                      <div className="flex items-center justify-between">
+                        <span className="text-sm">Drag & Drop</span>
+                        <Badge variant={capabilities.supportsDragAndDrop ? 'default' : 'destructive'}>
+                          {capabilities.supportsDragAndDrop ? 'Supported' : 'Not Supported'}
+                        </Badge>
+                      </div>
+                    </div>
+                  )}
+
+                  {capabilities?.mode === 'fallback' && (
+                    <div className="p-3 bg-yellow-50 dark:bg-yellow-900/20 rounded-lg">
+                      <div className="flex items-start gap-2">
+                        <Info className="h-4 w-4 text-yellow-600 dark:text-yellow-400 mt-0.5" />
+                        <div className="text-sm">
+                          <p className="font-medium text-yellow-800 dark:text-yellow-200 mb-1">
+                            Fallback Mode Information
+                          </p>
+                          <ul className="text-yellow-700 dark:text-yellow-300 space-y-1 text-xs">
+                            <li>• Chart scanning will be skipped - all songs will be available for download</li>
+                            <li>• Files will be downloaded instead of saved directly to folders</li>
+                            <li>• Advanced folder management features are not available</li>
+                            <li>• For the best experience, consider using Chrome or Edge</li>
+                          </ul>
+                        </div>
+                      </div>
+                    </div>
+                  )}
+
+                  {capabilities?.mode === 'unsupported' && (
+                    <div className="text-sm text-muted-foreground">
+                      <p className="mb-2">Supported browsers:</p>
+                      <ul className="list-disc list-inside space-y-1">
+                        <li>Google Chrome (recommended)</li>
+                        <li>Microsoft Edge</li>
+                        <li>Opera</li>
+                        <li>Brave Browser (with limited features)</li>
+                      </ul>
+                    </div>
+                  )}
+                </div>
+              </DialogContent>
+            </Dialog>
+          )}
+
+          {/* Authentication */}
+          {session?.status === 'loading' ? (
+            <div>Loading...</div>
+          ) : session?.status === 'authenticated' ? (
+            <div className="flex items-center space-x-2">
+              <span className="text-sm text-muted-foreground">
+                {session.data?.user?.name}
+              </span>
+              <Button onClick={() => signOut()} variant="outline" size="sm">
+                Sign out
+              </Button>
+            </div>
+          ) : (
+            <Button onClick={() => signIn('spotify')} size="sm">
+              <Icons.spotify className="h-4 w-4 mr-2" />
+              Sign in with Spotify
+            </Button>
+          )}
+        </div>
+      </div>
+    </header>
+  );
+}

--- a/spotify-clonehero-next/components/ui/alert.tsx
+++ b/spotify-clonehero-next/components/ui/alert.tsx
@@ -1,0 +1,58 @@
+import * as React from "react"
+import { cn } from "@/lib/utils"
+
+export interface AlertProps extends React.HTMLAttributes<HTMLDivElement> {
+  variant?: "default" | "destructive"
+}
+
+const getVariantClasses = (variant: AlertProps["variant"] = "default") => {
+  switch (variant) {
+    case "destructive":
+      return "border-destructive/50 text-destructive dark:border-destructive [&>svg]:text-destructive"
+    case "default":
+    default:
+      return "bg-background text-foreground"
+  }
+}
+
+const Alert = React.forwardRef<HTMLDivElement, AlertProps>(
+  ({ className, variant = "default", ...props }, ref) => (
+    <div
+      ref={ref}
+      role="alert"
+      className={cn(
+        "relative w-full rounded-lg border p-4 [&>svg~*]:pl-7 [&>svg+div]:translate-y-[-3px] [&>svg]:absolute [&>svg]:left-4 [&>svg]:top-4 [&>svg]:text-foreground",
+        getVariantClasses(variant),
+        className
+      )}
+      {...props}
+    />
+  )
+)
+Alert.displayName = "Alert"
+
+const AlertTitle = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLHeadingElement>
+>(({ className, ...props }, ref) => (
+  <h5
+    ref={ref}
+    className={cn("mb-1 font-medium leading-none tracking-tight", className)}
+    {...props}
+  />
+))
+AlertTitle.displayName = "AlertTitle"
+
+const AlertDescription = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLParagraphElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("text-sm [&_p]:leading-relaxed", className)}
+    {...props}
+  />
+))
+AlertDescription.displayName = "AlertDescription"
+
+export { Alert, AlertTitle, AlertDescription }

--- a/spotify-clonehero-next/components/ui/badge.tsx
+++ b/spotify-clonehero-next/components/ui/badge.tsx
@@ -1,0 +1,36 @@
+import * as React from "react"
+import { cn } from "@/lib/utils"
+
+export interface BadgeProps extends React.HTMLAttributes<HTMLDivElement> {
+  variant?: "default" | "secondary" | "destructive" | "outline"
+}
+
+const getVariantClasses = (variant: BadgeProps["variant"] = "default") => {
+  switch (variant) {
+    case "default":
+      return "border-transparent bg-primary text-primary-foreground hover:bg-primary/80"
+    case "secondary":
+      return "border-transparent bg-secondary text-secondary-foreground hover:bg-secondary/80"
+    case "destructive":
+      return "border-transparent bg-destructive text-destructive-foreground hover:bg-destructive/80"
+    case "outline":
+      return "text-foreground"
+    default:
+      return "border-transparent bg-primary text-primary-foreground hover:bg-primary/80"
+  }
+}
+
+function Badge({ className, variant = "default", ...props }: BadgeProps) {
+  return (
+    <div 
+      className={cn(
+        "inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",
+        getVariantClasses(variant),
+        className
+      )} 
+      {...props} 
+    />
+  )
+}
+
+export { Badge }

--- a/spotify-clonehero-next/components/ui/checkbox.tsx
+++ b/spotify-clonehero-next/components/ui/checkbox.tsx
@@ -1,0 +1,30 @@
+"use client"
+
+import * as React from "react"
+import * as CheckboxPrimitive from "@radix-ui/react-checkbox"
+import { Check } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+const Checkbox = React.forwardRef<
+  React.ElementRef<typeof CheckboxPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof CheckboxPrimitive.Root>
+>(({ className, ...props }, ref) => (
+  <CheckboxPrimitive.Root
+    ref={ref}
+    className={cn(
+      "peer h-4 w-4 shrink-0 rounded-sm border border-primary ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground",
+      className
+    )}
+    {...props}
+  >
+    <CheckboxPrimitive.Indicator
+      className={cn("flex items-center justify-center text-current")}
+    >
+      <Check className="h-4 w-4" />
+    </CheckboxPrimitive.Indicator>
+  </CheckboxPrimitive.Root>
+))
+Checkbox.displayName = CheckboxPrimitive.Root.displayName
+
+export { Checkbox }

--- a/spotify-clonehero-next/components/ui/collapsible.tsx
+++ b/spotify-clonehero-next/components/ui/collapsible.tsx
@@ -1,0 +1,12 @@
+"use client"
+
+import * as React from "react"
+import * as CollapsiblePrimitive from "@radix-ui/react-collapsible"
+
+const Collapsible = CollapsiblePrimitive.Root
+
+const CollapsibleTrigger = CollapsiblePrimitive.CollapsibleTrigger
+
+const CollapsibleContent = CollapsiblePrimitive.CollapsibleContent
+
+export { Collapsible, CollapsibleTrigger, CollapsibleContent }

--- a/spotify-clonehero-next/components/ui/tabs.tsx
+++ b/spotify-clonehero-next/components/ui/tabs.tsx
@@ -1,0 +1,55 @@
+"use client"
+
+import * as React from "react"
+import * as TabsPrimitive from "@radix-ui/react-tabs"
+
+import { cn } from "@/lib/utils"
+
+const Tabs = TabsPrimitive.Root
+
+const TabsList = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.List>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.List>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.List
+    ref={ref}
+    className={cn(
+      "inline-flex h-10 items-center justify-center rounded-md bg-muted p-1 text-muted-foreground",
+      className
+    )}
+    {...props}
+  />
+))
+TabsList.displayName = TabsPrimitive.List.displayName
+
+const TabsTrigger = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.Trigger>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Trigger>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.Trigger
+    ref={ref}
+    className={cn(
+      "inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm",
+      className
+    )}
+    {...props}
+  />
+))
+TabsTrigger.displayName = TabsPrimitive.Trigger.displayName
+
+const TabsContent = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Content>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.Content
+    ref={ref}
+    className={cn(
+      "mt-2 ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+      className
+    )}
+    {...props}
+  />
+))
+TabsContent.displayName = TabsPrimitive.Content.displayName
+
+export { Tabs, TabsList, TabsTrigger, TabsContent }

--- a/spotify-clonehero-next/lib/browser-compat/FileSystemCompat.ts
+++ b/spotify-clonehero-next/lib/browser-compat/FileSystemCompat.ts
@@ -1,0 +1,307 @@
+/**
+ * Browser Compatibility Layer for File System Access
+ * Provides fallbacks for browsers that don't support File System Access API
+ */
+
+export type CompatibilityMode = 'native' | 'fallback' | 'unsupported';
+
+export interface BrowserCapabilities {
+  mode: CompatibilityMode;
+  canReadDirectories: boolean;
+  canWriteFiles: boolean;
+  canDownloadFiles: boolean;
+  supportsDirectoryPicker: boolean;
+  supportsDragAndDrop: boolean;
+}
+
+export interface FileEntry {
+  name: string;
+  type: 'file' | 'directory';
+  file?: File;
+  children?: FileEntry[];
+}
+
+// Detect browser capabilities
+export function detectBrowserCapabilities(): BrowserCapabilities {
+  const hasFileSystemAccess = 
+    typeof window !== 'undefined' &&
+    typeof window.showDirectoryPicker === 'function' &&
+    typeof window.FileSystemDirectoryHandle !== 'undefined';
+
+  const hasFileAPI = 
+    typeof window !== 'undefined' &&
+    typeof window.File !== 'undefined' &&
+    typeof window.FileReader !== 'undefined';
+
+  const hasDragAndDrop = 
+    typeof window !== 'undefined' &&
+    typeof window.DataTransfer !== 'undefined';
+
+  if (hasFileSystemAccess) {
+    return {
+      mode: 'native',
+      canReadDirectories: true,
+      canWriteFiles: true,
+      canDownloadFiles: true,
+      supportsDirectoryPicker: true,
+      supportsDragAndDrop: true,
+    };
+  } else if (hasFileAPI) {
+    return {
+      mode: 'fallback',
+      canReadDirectories: true, // via drag & drop or file input
+      canWriteFiles: false,     // can only download
+      canDownloadFiles: true,
+      supportsDirectoryPicker: false,
+      supportsDragAndDrop: hasDragAndDrop,
+    };
+  } else {
+    return {
+      mode: 'unsupported',
+      canReadDirectories: false,
+      canWriteFiles: false,
+      canDownloadFiles: false,
+      supportsDirectoryPicker: false,
+      supportsDragAndDrop: false,
+    };
+  }
+}
+
+// Fallback directory picker using file input with webkitdirectory
+export async function showDirectoryPickerFallback(): Promise<FileEntry[]> {
+  return new Promise((resolve, reject) => {
+    const input = document.createElement('input');
+    input.type = 'file';
+    input.webkitdirectory = true;
+    input.multiple = true;
+    
+    const timeout = setTimeout(() => {
+      reject(new Error('User canceled picker'));
+    }, 60000); // 1 minute timeout
+
+    input.onchange = (event) => {
+      clearTimeout(timeout);
+      const files = Array.from((event.target as HTMLInputElement).files || []);
+      
+      if (files.length === 0) {
+        reject(new Error('User canceled picker'));
+        return;
+      }
+
+      const fileTree = buildFileTree(files);
+      resolve(fileTree);
+    };
+
+    input.oncancel = () => {
+      clearTimeout(timeout);
+      reject(new Error('User canceled picker'));
+    };
+
+    // Trigger the file picker
+    input.click();
+  });
+}
+
+// Build a file tree from flat file list
+function buildFileTree(files: File[]): FileEntry[] {
+  const tree: { [path: string]: FileEntry } = {};
+  const roots: FileEntry[] = [];
+
+  files.forEach(file => {
+    const pathParts = file.webkitRelativePath.split('/');
+    let currentPath = '';
+
+    for (let i = 0; i < pathParts.length; i++) {
+      const part = pathParts[i];
+      const parentPath = currentPath;
+      currentPath = currentPath ? `${currentPath}/${part}` : part;
+      
+      if (!tree[currentPath]) {
+        const isFile = i === pathParts.length - 1;
+        const entry: FileEntry = {
+          name: part,
+          type: isFile ? 'file' : 'directory',
+          ...(isFile && { file }),
+          ...(!isFile && { children: [] })
+        };
+        
+        tree[currentPath] = entry;
+        
+        if (parentPath && tree[parentPath]?.children) {
+          tree[parentPath].children!.push(entry);
+        } else if (i === 0) {
+          roots.push(entry);
+        }
+      }
+    }
+  });
+
+  return roots;
+}
+
+// Unified directory picker that uses native API or fallback
+export async function showDirectoryPicker(): Promise<FileEntry[] | FileSystemDirectoryHandle> {
+  const capabilities = detectBrowserCapabilities();
+  
+  if (capabilities.mode === 'native') {
+    // Use native API
+    try {
+      const handle = await window.showDirectoryPicker({
+        id: 'clone-hero-songs',
+        mode: 'readwrite',
+      });
+      return handle;
+    } catch (err) {
+      throw new Error('User canceled picker');
+    }
+  } else if (capabilities.mode === 'fallback') {
+    // Use fallback method
+    return await showDirectoryPickerFallback();
+  } else {
+    throw new Error('Directory selection not supported in this browser');
+  }
+}
+
+// Download file function that works across browsers
+export function downloadFile(filename: string, content: Blob | string) {
+  const blob = content instanceof Blob ? content : new Blob([content]);
+  
+  if (window.navigator && (window.navigator as any).msSaveBlob) {
+    // IE/Edge legacy support
+    (window.navigator as any).msSaveBlob(blob, filename);
+    return;
+  }
+
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = filename;
+  link.style.display = 'none';
+  
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  
+  // Clean up
+  setTimeout(() => URL.revokeObjectURL(url), 100);
+}
+
+// Check if a file matches common chart file patterns
+export function isChartFile(filename: string): boolean {
+  const chartExtensions = ['.chart', '.mid', '.midi'];
+  const lowerName = filename.toLowerCase();
+  return chartExtensions.some(ext => lowerName.endsWith(ext));
+}
+
+// Check if a file is a song.ini file
+export function isSongIniFile(filename: string): boolean {
+  return filename.toLowerCase() === 'song.ini';
+}
+
+// Extract chart information from file tree (fallback scanning)
+export async function scanChartsFromFileTree(fileTree: FileEntry[]): Promise<any[]> {
+  const charts: any[] = [];
+  
+  async function scanDirectory(entries: FileEntry[], path: string = '') {
+    for (const entry of entries) {
+      if (entry.type === 'directory' && entry.children) {
+        // Check if this directory contains chart files
+        const hasChartFiles = entry.children.some(child => 
+          child.type === 'file' && isChartFile(child.name)
+        );
+        
+        const hasSongIni = entry.children.some(child =>
+          child.type === 'file' && isSongIniFile(child.name)
+        );
+
+        if (hasChartFiles || hasSongIni) {
+          // This looks like a chart directory
+          const songIniFile = entry.children.find(child => 
+            child.type === 'file' && isSongIniFile(child.name)
+          );
+
+          let songInfo = {
+            artist: 'Unknown Artist',
+            name: entry.name,
+            charter: 'Unknown Charter',
+            folder: `${path}${entry.name}`,
+            hasChart: hasChartFiles,
+            hasSongIni: !!songIniFile,
+          };
+
+          // Try to read song.ini if available
+          if (songIniFile?.file) {
+            try {
+              const iniContent = await songIniFile.file.text();
+              const parsedIni = parseSongIni(iniContent);
+              songInfo = { ...songInfo, ...parsedIni };
+            } catch (error) {
+              console.warn('Error reading song.ini:', error);
+            }
+          }
+
+          charts.push(songInfo);
+        }
+        
+        // Recursively scan subdirectories
+        await scanDirectory(entry.children, `${path}${entry.name}/`);
+      }
+    }
+  }
+  
+  await scanDirectory(fileTree);
+  return charts;
+}
+
+// Simple song.ini parser
+function parseSongIni(content: string): Partial<any> {
+  const lines = content.split('\n');
+  const result: any = {};
+  
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (trimmed && !trimmed.startsWith('[') && !trimmed.startsWith('#')) {
+      const [key, ...valueParts] = trimmed.split('=');
+      if (key && valueParts.length > 0) {
+        const value = valueParts.join('=').trim();
+        const cleanKey = key.trim().toLowerCase();
+        
+        if (cleanKey === 'artist') result.artist = value;
+        else if (cleanKey === 'name') result.name = value;
+        else if (cleanKey === 'charter') result.charter = value;
+        else if (cleanKey === 'frets') result.charter = value; // Alternative charter field
+      }
+    }
+  }
+  
+  return result;
+}
+
+// Create a compatibility wrapper for existing functions
+export class FileSystemCompat {
+  private capabilities: BrowserCapabilities;
+  
+  constructor() {
+    this.capabilities = detectBrowserCapabilities();
+  }
+
+  getCapabilities(): BrowserCapabilities {
+    return this.capabilities;
+  }
+
+  async selectDirectory(): Promise<FileEntry[] | FileSystemDirectoryHandle> {
+    return await showDirectoryPicker();
+  }
+
+  canWriteFiles(): boolean {
+    return this.capabilities.canWriteFiles;
+  }
+
+  canReadDirectories(): boolean {
+    return this.capabilities.canReadDirectories;
+  }
+
+  downloadFile(filename: string, content: Blob | string) {
+    return downloadFile(filename, content);
+  }
+}

--- a/spotify-clonehero-next/lib/local-songs-folder/index-compat.ts
+++ b/spotify-clonehero-next/lib/local-songs-folder/index-compat.ts
@@ -1,0 +1,322 @@
+import {set, get} from 'idb-keyval';
+import filenamify from 'filenamify/browser';
+import {sendGAEvent} from '@next/third-parties/google';
+
+import {
+  detectBrowserCapabilities,
+  showDirectoryPicker,
+  downloadFile,
+  scanChartsFromFileTree,
+  type FileEntry
+} from '@/lib/browser-compat/FileSystemCompat';
+import {SongAccumulator} from './scanLocalCharts';
+
+// Storage key for fallback mode chart data
+const FALLBACK_CHARTS_KEY = 'fallback-scanned-charts';
+const FALLBACK_SCAN_TIME_KEY = 'fallback-scan-time';
+
+export interface ScanResult {
+  lastScanned: Date;
+  installedCharts: SongAccumulator[];
+  mode: 'native' | 'fallback';
+}
+
+/**
+ * Enhanced directory picker that works across browsers
+ */
+export async function promptForSongsDirectoryCompat(): Promise<FileEntry[] | FileSystemDirectoryHandle> {
+  const capabilities = detectBrowserCapabilities();
+  
+  if (capabilities.mode === 'unsupported') {
+    throw new Error('File system access not supported in this browser');
+  }
+
+  try {
+    const result = await showDirectoryPicker();
+    return result;
+  } catch (err: any) {
+    if (err.message.includes('canceled')) {
+      throw new Error('User canceled picker');
+    }
+    throw err;
+  }
+}
+
+/**
+ * Scan for installed charts with browser compatibility
+ */
+export async function scanForInstalledChartsCompat(
+  callbackPerSong: () => void = () => {},
+): Promise<ScanResult> {
+  const capabilities = detectBrowserCapabilities();
+  
+  if (capabilities.mode === 'native') {
+    // Use existing native implementation
+    return await scanForInstalledChartsNative(callbackPerSong);
+  } else if (capabilities.mode === 'fallback') {
+    // Use fallback implementation
+    return await scanForInstalledChartsFallback(callbackPerSong);
+  } else {
+    throw new Error('Chart scanning not supported in this browser');
+  }
+}
+
+/**
+ * Native implementation (existing logic)
+ */
+async function scanForInstalledChartsNative(
+  callbackPerSong: () => void
+): Promise<ScanResult> {
+  const root = await navigator.storage.getDirectory();
+  
+  let handle: FileSystemDirectoryHandle;
+  try {
+    handle = await (window as any).showDirectoryPicker({
+      id: 'clone-hero-songs',
+      mode: 'readwrite',
+    });
+  } catch (err) {
+    throw new Error('User canceled picker');
+  }
+
+  await set('songsDirectoryHandle', handle);
+
+  const beforeScan = Date.now();
+  const installedCharts: SongAccumulator[] = [];
+  
+  // Import the scanLocalCharts function
+  const { default: scanLocalCharts } = await import('./scanLocalCharts');
+  await scanLocalCharts(handle, installedCharts, callbackPerSong);
+  
+  console.log(
+    'Took',
+    (Date.now() - beforeScan) / 1000,
+    'ss to scan',
+    installedCharts.length,
+  );
+
+  sendGAEvent({
+    event: 'charts_scanned',
+    value: installedCharts.length,
+  });
+
+  // Cache results
+  const installedChartsCacheHandle = await root.getFileHandle(
+    'installedCharts.json',
+    { create: true }
+  );
+  
+  const writableStream = await installedChartsCacheHandle.createWritable();
+  await writableStream.write(JSON.stringify(installedCharts));
+  await writableStream.close();
+  
+  const now = new Date();
+  localStorage.setItem(
+    'lastScannedInstalledCharts',
+    now.getTime().toString(),
+  );
+
+  return {
+    lastScanned: now,
+    installedCharts,
+    mode: 'native'
+  };
+}
+
+/**
+ * Fallback implementation for browsers without File System Access API
+ */
+async function scanForInstalledChartsFallback(
+  callbackPerSong: () => void
+): Promise<ScanResult> {
+  // Show instructions to user
+  alert(
+    'Your browser doesn\'t support native directory access. ' +
+    'Please select your Clone Hero Songs folder in the file picker dialog. ' +
+    'Make sure to select the entire folder structure.'
+  );
+
+  const fileTree = await showDirectoryPicker() as FileEntry[];
+  
+  if (!Array.isArray(fileTree)) {
+    throw new Error('Expected file tree array in fallback mode');
+  }
+
+  const beforeScan = Date.now();
+  
+  // Scan the file tree for charts
+  const charts = await scanChartsFromFileTree(fileTree);
+  
+  // Convert to SongAccumulator format
+  const installedCharts: SongAccumulator[] = charts.map((chart, index) => {
+    callbackPerSong(); // Call progress callback
+    
+    return {
+      artist: chart.artist || 'Unknown Artist',
+      song: chart.name || 'Unknown Song',
+      charter: chart.charter || 'Unknown Charter',
+      folder: chart.folder || '',
+      hasChart: chart.hasChart || false,
+      hasSongIni: chart.hasSongIni || false,
+      // Add other required fields with defaults
+      avoidedFolders: 0,
+      filesScanned: 1,
+      songsScanned: 1,
+    };
+  });
+
+  console.log(
+    'Took',
+    (Date.now() - beforeScan) / 1000,
+    'ss to scan',
+    installedCharts.length,
+    'charts in fallback mode'
+  );
+
+  sendGAEvent({
+    event: 'charts_scanned_fallback',
+    value: installedCharts.length,
+  });
+
+  // Cache results in localStorage/IndexedDB
+  await set(FALLBACK_CHARTS_KEY, installedCharts);
+  
+  const now = new Date();
+  await set(FALLBACK_SCAN_TIME_KEY, now.getTime());
+
+  return {
+    lastScanned: now,
+    installedCharts,
+    mode: 'fallback'
+  };
+}
+
+/**
+ * Download song with browser compatibility
+ */
+export async function downloadSongCompat(
+  artist: string,
+  song: string,
+  charter: string,
+  url: string,
+  options?: {
+    replaceExisting?: boolean;
+    asSng?: boolean;
+  },
+): Promise<{success: boolean; filename: string; mode: 'native' | 'fallback'}> {
+  const capabilities = detectBrowserCapabilities();
+  
+  sendGAEvent({
+    event: 'download_song_compat',
+    value: capabilities.mode,
+  });
+
+  if (capabilities.mode === 'native') {
+    // Use existing native implementation
+    const { downloadSong } = await import('./index');
+    try {
+      const result = await downloadSong(artist, song, charter, url, options);
+      return {
+        success: !!result,
+        filename: result?.fileName || '',
+        mode: 'native'
+      };
+    } catch (error) {
+      console.error('Native download failed:', error);
+      throw error;
+    }
+  } else {
+    // Use fallback download
+    return await downloadSongFallback(artist, song, charter, url, options);
+  }
+}
+
+/**
+ * Fallback download implementation
+ */
+async function downloadSongFallback(
+  artist: string,
+  song: string,
+  charter: string,
+  url: string,
+  options?: {
+    replaceExisting?: boolean;
+    asSng?: boolean;
+  },
+): Promise<{success: boolean; filename: string; mode: 'fallback'}> {
+  try {
+    const response = await fetch(url, {
+      headers: {
+        accept: '*/*',
+        'accept-language': 'en-US,en;q=0.9',
+        'sec-fetch-dest': 'empty',
+      },
+      referrerPolicy: 'no-referrer',
+      method: 'GET',
+      credentials: 'omit',
+      cache: 'no-store',
+    });
+
+    if (!response.ok) {
+      throw new Error(`HTTP error! status: ${response.status}`);
+    }
+
+    const blob = await response.blob();
+    const artistSongTitle = `${artist} - ${song} (${charter})${
+      options?.asSng ? '.sng' : '.zip'
+    }`;
+    const filename = filenamify(artistSongTitle, {replacement: ''});
+
+    // Download file using browser's download mechanism
+    downloadFile(filename, blob);
+
+    console.log(`Downloaded ${filename} using fallback method`);
+    
+    return {
+      success: true,
+      filename,
+      mode: 'fallback'
+    };
+  } catch (error) {
+    console.error('Fallback download failed:', error);
+    throw error;
+  }
+}
+
+/**
+ * Get cached scan results for fallback mode
+ */
+export async function getCachedScanResults(): Promise<ScanResult | null> {
+  const capabilities = detectBrowserCapabilities();
+  
+  if (capabilities.mode === 'fallback') {
+    const charts = await get(FALLBACK_CHARTS_KEY);
+    const scanTime = await get(FALLBACK_SCAN_TIME_KEY);
+    
+    if (charts && scanTime) {
+      return {
+        lastScanned: new Date(scanTime),
+        installedCharts: charts,
+        mode: 'fallback'
+      };
+    }
+  }
+  
+  return null;
+}
+
+/**
+ * Check if browser supports chart scanning
+ */
+export function canScanCharts(): boolean {
+  const capabilities = detectBrowserCapabilities();
+  return capabilities.canReadDirectories;
+}
+
+/**
+ * Check if browser supports file downloads
+ */
+export function canDownloadFiles(): boolean {
+  const capabilities = detectBrowserCapabilities();
+  return capabilities.canDownloadFiles;
+}

--- a/spotify-clonehero-next/package.json
+++ b/spotify-clonehero-next/package.json
@@ -15,6 +15,8 @@
   "dependencies": {
     "@headlessui/react": "^1.7.17",
     "@next/third-parties": "15.3.3",
+    "@radix-ui/react-checkbox": "^1.3.3",
+    "@radix-ui/react-collapsible": "^1.1.12",
     "@radix-ui/react-dialog": "^1.1.6",
     "@radix-ui/react-dropdown-menu": "^2.0.6",
     "@radix-ui/react-label": "^2.1.2",
@@ -22,6 +24,7 @@
     "@radix-ui/react-slider": "^1.2.3",
     "@radix-ui/react-slot": "^1.0.2",
     "@radix-ui/react-switch": "^1.1.3",
+    "@radix-ui/react-tabs": "^1.1.13",
     "@sentry/nextjs": "^7.92.0",
     "@spotify/web-api-ts-sdk": "^1.1.2",
     "@tanstack/react-table": "^8.10.7",

--- a/spotify-clonehero-next/yarn.lock
+++ b/spotify-clonehero-next/yarn.lock
@@ -940,6 +940,11 @@
   resolved "https://registry.yarnpkg.com/@radix-ui/primitive/-/primitive-1.1.1.tgz#fc169732d755c7fbad33ba8d0cd7fd10c90dc8e3"
   integrity sha512-SJ31y+Q/zAyShtXJc8x83i9TYdbAfHZ++tUZnvjJJqFjzsdUnKsxPL6IEtBlxKkU7yzer//GQtZSV4GbldL3YA==
 
+"@radix-ui/primitive@1.1.3":
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/@radix-ui/primitive/-/primitive-1.1.3.tgz#e2dbc13bdc5e4168f4334f75832d7bdd3e2de5ba"
+  integrity sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==
+
 "@radix-ui/react-arrow@1.0.3":
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-arrow/-/react-arrow-1.0.3.tgz#c24f7968996ed934d57fe6cde5d6ec7266e1d25d"
@@ -954,6 +959,34 @@
   integrity sha512-G+KcpzXHq24iH0uGG/pF8LyzpFJYGD4RfLjCIBfGdSLXvjLHST31RUiRVrupIBMvIppMgSzQ6l66iAxl03tdlg==
   dependencies:
     "@radix-ui/react-primitive" "2.0.2"
+
+"@radix-ui/react-checkbox@^1.3.3":
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-checkbox/-/react-checkbox-1.3.3.tgz#db45ca8a6d5c056a92f74edbb564acee05318b79"
+  integrity sha512-wBbpv+NQftHDdG86Qc0pIyXk5IR3tM8Vd0nWLKDcX8nNn4nXFOFwsKuqw2okA/1D/mpaAkmuyndrPJTYDNZtFw==
+  dependencies:
+    "@radix-ui/primitive" "1.1.3"
+    "@radix-ui/react-compose-refs" "1.1.2"
+    "@radix-ui/react-context" "1.1.2"
+    "@radix-ui/react-presence" "1.1.5"
+    "@radix-ui/react-primitive" "2.1.3"
+    "@radix-ui/react-use-controllable-state" "1.2.2"
+    "@radix-ui/react-use-previous" "1.1.1"
+    "@radix-ui/react-use-size" "1.1.1"
+
+"@radix-ui/react-collapsible@^1.1.12":
+  version "1.1.12"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-collapsible/-/react-collapsible-1.1.12.tgz#e2cc69a4490a2920f97c3c3150b0bf21281e3c49"
+  integrity sha512-Uu+mSh4agx2ib1uIGPP4/CKNULyajb3p92LsVXmH2EHVMTfZWpll88XJ0j4W0z3f8NK1eYl1+Mf/szHPmcHzyA==
+  dependencies:
+    "@radix-ui/primitive" "1.1.3"
+    "@radix-ui/react-compose-refs" "1.1.2"
+    "@radix-ui/react-context" "1.1.2"
+    "@radix-ui/react-id" "1.1.1"
+    "@radix-ui/react-presence" "1.1.5"
+    "@radix-ui/react-primitive" "2.1.3"
+    "@radix-ui/react-use-controllable-state" "1.2.2"
+    "@radix-ui/react-use-layout-effect" "1.1.1"
 
 "@radix-ui/react-collection@1.0.3":
   version "1.0.3"
@@ -976,6 +1009,16 @@
     "@radix-ui/react-primitive" "2.0.2"
     "@radix-ui/react-slot" "1.1.2"
 
+"@radix-ui/react-collection@1.1.7":
+  version "1.1.7"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-collection/-/react-collection-1.1.7.tgz#d05c25ca9ac4695cc19ba91f42f686e3ea2d9aec"
+  integrity sha512-Fh9rGN0MoI4ZFUNyfFVNU4y9LUz93u9/0K+yLgA2bwRojxM8JU1DyvvMBabnZPBgMWREAJvU2jjVzq+LrFUglw==
+  dependencies:
+    "@radix-ui/react-compose-refs" "1.1.2"
+    "@radix-ui/react-context" "1.1.2"
+    "@radix-ui/react-primitive" "2.1.3"
+    "@radix-ui/react-slot" "1.2.3"
+
 "@radix-ui/react-compose-refs@1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-compose-refs/-/react-compose-refs-1.0.1.tgz#7ed868b66946aa6030e580b1ffca386dd4d21989"
@@ -988,6 +1031,11 @@
   resolved "https://registry.yarnpkg.com/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.1.tgz#6f766faa975f8738269ebb8a23bad4f5a8d2faec"
   integrity sha512-Y9VzoRDSJtgFMUCoiZBDVo084VQ5hfpXxVE+NgkdNsjiDBByiImMZKKhxMwCbdHvhlENG6a833CbFkOQvTricw==
 
+"@radix-ui/react-compose-refs@1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.2.tgz#a2c4c47af6337048ee78ff6dc0d090b390d2bb30"
+  integrity sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==
+
 "@radix-ui/react-context@1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-context/-/react-context-1.0.1.tgz#fe46e67c96b240de59187dcb7a1a50ce3e2ec00c"
@@ -999,6 +1047,11 @@
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-context/-/react-context-1.1.1.tgz#82074aa83a472353bb22e86f11bcbd1c61c4c71a"
   integrity sha512-UASk9zi+crv9WteK/NU4PLvOoL3OuE6BWVKNF6hPRBtYBDXQ2u5iu3O59zUlJiTVvkyuycnqrztsHVJwcK9K+Q==
+
+"@radix-ui/react-context@1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-context/-/react-context-1.1.2.tgz#61628ef269a433382c364f6f1e3788a6dc213a36"
+  integrity sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==
 
 "@radix-ui/react-dialog@^1.1.6":
   version "1.1.6"
@@ -1031,6 +1084,11 @@
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-direction/-/react-direction-1.1.0.tgz#a7d39855f4d077adc2a1922f9c353c5977a09cdc"
   integrity sha512-BUuBvgThEiAXh2DWu93XsT+a3aWrGqolGlqqw5VU1kG7p/ZH2cuDlM1sRLNnY3QcBS69UIz2mcKhMxDsdewhjg==
+
+"@radix-ui/react-direction@1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-direction/-/react-direction-1.1.1.tgz#39e5a5769e676c753204b792fbe6cf508e550a14"
+  integrity sha512-1UEWRX6jnOA2y4H5WczZ44gOOjTEmlqv1uNW4GAJEO5+bauCBhv8snY65Iw5/VOS/ghKN9gr2KjnLKxrsvoMVw==
 
 "@radix-ui/react-dismissable-layer@1.0.5":
   version "1.0.5"
@@ -1114,6 +1172,13 @@
   integrity sha512-EJUrI8yYh7WOjNOqpoJaf1jlFIH2LvtgAl+YcFqNCa+4hj64ZXmPkAKOFs/ukjz3byN6bdb/AVUqHkI8/uWWMA==
   dependencies:
     "@radix-ui/react-use-layout-effect" "1.1.0"
+
+"@radix-ui/react-id@1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-id/-/react-id-1.1.1.tgz#1404002e79a03fe062b7e3864aa01e24bd1471f7"
+  integrity sha512-kGkGegYIdQsOb4XjsfM97rXsiHaBwco+hFI66oO4s9LU+PLAC5oJ7khdOVFxkhsmlbpUqDAvXw11CluXP+jkHg==
+  dependencies:
+    "@radix-ui/react-use-layout-effect" "1.1.1"
 
 "@radix-ui/react-label@^2.1.2":
   version "2.1.2"
@@ -1213,6 +1278,14 @@
     "@radix-ui/react-compose-refs" "1.1.1"
     "@radix-ui/react-use-layout-effect" "1.1.0"
 
+"@radix-ui/react-presence@1.1.5":
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-presence/-/react-presence-1.1.5.tgz#5d8f28ac316c32f078afce2996839250c10693db"
+  integrity sha512-/jfEwNDdQVBCNvjkGit4h6pMOzq8bHkopq458dPt2lMjx+eBQUohZNG9A7DtO/O5ukSbxuaNGXMjHicgwy6rQQ==
+  dependencies:
+    "@radix-ui/react-compose-refs" "1.1.2"
+    "@radix-ui/react-use-layout-effect" "1.1.1"
+
 "@radix-ui/react-primitive@1.0.3":
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-primitive/-/react-primitive-1.0.3.tgz#d49ea0f3f0b2fe3ab1cb5667eb03e8b843b914d0"
@@ -1227,6 +1300,13 @@
   integrity sha512-Ec/0d38EIuvDF+GZjcMU/Ze6MxntVJYO/fRlCPhCaVUyPY9WTalHJw54tp9sXeJo3tlShWpy41vQRgLRGOuz+w==
   dependencies:
     "@radix-ui/react-slot" "1.1.2"
+
+"@radix-ui/react-primitive@2.1.3":
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz#db9b8bcff49e01be510ad79893fb0e4cda50f1bc"
+  integrity sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==
+  dependencies:
+    "@radix-ui/react-slot" "1.2.3"
 
 "@radix-ui/react-roving-focus@1.0.4":
   version "1.0.4"
@@ -1243,6 +1323,21 @@
     "@radix-ui/react-primitive" "1.0.3"
     "@radix-ui/react-use-callback-ref" "1.0.1"
     "@radix-ui/react-use-controllable-state" "1.0.1"
+
+"@radix-ui/react-roving-focus@1.1.11":
+  version "1.1.11"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-roving-focus/-/react-roving-focus-1.1.11.tgz#ef54384b7361afc6480dcf9907ef2fedb5080fd9"
+  integrity sha512-7A6S9jSgm/S+7MdtNDSb+IU859vQqJ/QAtcYQcfFC6W8RS4IxIZDldLR0xqCFZ6DCyrQLjLPsxtTNch5jVA4lA==
+  dependencies:
+    "@radix-ui/primitive" "1.1.3"
+    "@radix-ui/react-collection" "1.1.7"
+    "@radix-ui/react-compose-refs" "1.1.2"
+    "@radix-ui/react-context" "1.1.2"
+    "@radix-ui/react-direction" "1.1.1"
+    "@radix-ui/react-id" "1.1.1"
+    "@radix-ui/react-primitive" "2.1.3"
+    "@radix-ui/react-use-callback-ref" "1.1.1"
+    "@radix-ui/react-use-controllable-state" "1.2.2"
 
 "@radix-ui/react-select@^2.1.6":
   version "2.1.6"
@@ -1303,6 +1398,13 @@
   dependencies:
     "@radix-ui/react-compose-refs" "1.1.1"
 
+"@radix-ui/react-slot@1.2.3":
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-slot/-/react-slot-1.2.3.tgz#502d6e354fc847d4169c3bc5f189de777f68cfe1"
+  integrity sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==
+  dependencies:
+    "@radix-ui/react-compose-refs" "1.1.2"
+
 "@radix-ui/react-switch@^1.1.3":
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-switch/-/react-switch-1.1.3.tgz#cb6386909d1d3f65a2b81a3b15da8c91d18f49b0"
@@ -1316,6 +1418,20 @@
     "@radix-ui/react-use-previous" "1.1.0"
     "@radix-ui/react-use-size" "1.1.0"
 
+"@radix-ui/react-tabs@^1.1.13":
+  version "1.1.13"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-tabs/-/react-tabs-1.1.13.tgz#3537ce379d7e7ff4eeb6b67a0973e139c2ac1f15"
+  integrity sha512-7xdcatg7/U+7+Udyoj2zodtI9H/IIopqo+YOIcZOq1nJwXWBZ9p8xiu5llXlekDbZkca79a/fozEYQXIA4sW6A==
+  dependencies:
+    "@radix-ui/primitive" "1.1.3"
+    "@radix-ui/react-context" "1.1.2"
+    "@radix-ui/react-direction" "1.1.1"
+    "@radix-ui/react-id" "1.1.1"
+    "@radix-ui/react-presence" "1.1.5"
+    "@radix-ui/react-primitive" "2.1.3"
+    "@radix-ui/react-roving-focus" "1.1.11"
+    "@radix-ui/react-use-controllable-state" "1.2.2"
+
 "@radix-ui/react-use-callback-ref@1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.0.1.tgz#f4bb1f27f2023c984e6534317ebc411fc181107a"
@@ -1327,6 +1443,11 @@
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.0.tgz#bce938ca413675bc937944b0d01ef6f4a6dc5bf1"
   integrity sha512-CasTfvsy+frcFkbXtSJ2Zu9JHpN8TYKxkgJGWbjiZhFivxaeW7rMeZt7QELGVLaYVfFMsKHjb7Ak0nMEe+2Vfw==
+
+"@radix-ui/react-use-callback-ref@1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.1.tgz#62a4dba8b3255fdc5cc7787faeac1c6e4cc58d40"
+  integrity sha512-FkBMwD+qbGQeMu1cOHnuGB6x4yzPjho8ap5WtbEJ26umhgqVXbhekKUQO+hZEL1vU92a3wHwdp0HAcqAUF5iDg==
 
 "@radix-ui/react-use-controllable-state@1.0.1":
   version "1.0.1"
@@ -1342,6 +1463,21 @@
   integrity sha512-MtfMVJiSr2NjzS0Aa90NPTnvTSg6C/JLCV7ma0W6+OMV78vd8OyRpID+Ng9LxzsPbLeuBnWBA1Nq30AtBIDChw==
   dependencies:
     "@radix-ui/react-use-callback-ref" "1.1.0"
+
+"@radix-ui/react-use-controllable-state@1.2.2":
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.2.tgz#905793405de57d61a439f4afebbb17d0645f3190"
+  integrity sha512-BjasUjixPFdS+NKkypcyyN5Pmg83Olst0+c6vGov0diwTEo6mgdqVR6hxcEgFuh4QrAs7Rc+9KuGJ9TVCj0Zzg==
+  dependencies:
+    "@radix-ui/react-use-effect-event" "0.0.2"
+    "@radix-ui/react-use-layout-effect" "1.1.1"
+
+"@radix-ui/react-use-effect-event@0.0.2":
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.2.tgz#090cf30d00a4c7632a15548512e9152217593907"
+  integrity sha512-Qp8WbZOBe+blgpuUT+lw2xheLP8q0oatc9UpmiemEICxGvFLYmHm9QowVZGHtJlGbS6A6yJ3iViad/2cVjnOiA==
+  dependencies:
+    "@radix-ui/react-use-layout-effect" "1.1.1"
 
 "@radix-ui/react-use-escape-keydown@1.0.3":
   version "1.0.3"
@@ -1370,10 +1506,20 @@
   resolved "https://registry.yarnpkg.com/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.0.tgz#3c2c8ce04827b26a39e442ff4888d9212268bd27"
   integrity sha512-+FPE0rOdziWSrH9athwI1R0HDVbWlEhd+FR+aSDk4uWGmSJ9Z54sdZVDQPZAinJhJXwfT+qnj969mCsT2gfm5w==
 
+"@radix-ui/react-use-layout-effect@1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.1.tgz#0c4230a9eed49d4589c967e2d9c0d9d60a23971e"
+  integrity sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==
+
 "@radix-ui/react-use-previous@1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-use-previous/-/react-use-previous-1.1.0.tgz#d4dd37b05520f1d996a384eb469320c2ada8377c"
   integrity sha512-Z/e78qg2YFnnXcW88A4JmTtm4ADckLno6F7OXotmkQfeuCVaKuYzqAATPhVzl3delXE7CxIV8shofPn3jPc5Og==
+
+"@radix-ui/react-use-previous@1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-use-previous/-/react-use-previous-1.1.1.tgz#1a1ad5568973d24051ed0af687766f6c7cb9b5b5"
+  integrity sha512-2dHfToCj/pzca2Ck724OZ5L0EVrr3eHRNsG/b3xQJLA2hZpVCS99bLAX+hm1IHXDEnzU6by5z/5MIY794/a8NQ==
 
 "@radix-ui/react-use-rect@1.0.1":
   version "1.0.1"
@@ -1404,6 +1550,13 @@
   integrity sha512-XW3/vWuIXHa+2Uwcc2ABSfcCledmXhhQPlGbfcRXbiUQI5Icjcg19BGCZVKKInYbvUCut/ufbbLLPFC5cbb1hw==
   dependencies:
     "@radix-ui/react-use-layout-effect" "1.1.0"
+
+"@radix-ui/react-use-size@1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-use-size/-/react-use-size-1.1.1.tgz#6de276ffbc389a537ffe4316f5b0f24129405b37"
+  integrity sha512-ewrXRDTAqAXlkl6t/fkXWNAhFX9I+CkKlw6zjEwk86RSPKwZr3xpBRso655aqYafwtnbpHLj6toFzmd6xdVptQ==
+  dependencies:
+    "@radix-ui/react-use-layout-effect" "1.1.1"
 
 "@radix-ui/react-visually-hidden@1.1.2":
   version "1.1.2"


### PR DESCRIPTION
Hello! I don't know if you are accepting any contributions, but on my branch I have added some functionality that i found useful for searching through my music. Maybe it's useful for you too.
The features are as follow:
1. Add support for non GoogleChrome Browsers: by just not necesarily using the directory but still being able to use spotify sync
2. Add a GlobalHeader for login and login out (since the history and spotify use the same i though it might be usefull to 1 header)
<img width="1467" height="733" alt="image" src="https://github.com/user-attachments/assets/a501d77e-0499-4f76-b28f-aa68f643694b" />

** For non compatible browsers there is a warning like this:
<img width="733" height="436" alt="image" src="https://github.com/user-attachments/assets/23041086-fdeb-4e34-9ff9-5a7f75a3de95" />
3. Playlist search like this:
<img width="746" height="790" alt="image" src="https://github.com/user-attachments/assets/00e7570b-67aa-4bd9-935e-837a7864d6e7" />

when selecting one you get filtered songs only belonging from that playlist

4. And all song selector with filters to make it easier to find like this:
<img width="722" height="709" alt="image" src="https://github.com/user-attachments/assets/9c755074-ff00-454b-812c-83e6fab3a872" />
