### PR TITLE
Fix sheet music audio not playing on mobile

### DIFF
--- a/spotify-clonehero-next/lib/preview/audioManager.ts
+++ b/spotify-clonehero-next/lib/preview/audioManager.ts
@@ -60,8 +60,9 @@ export class AudioManager {
   }
 
   async #createTracks(audioFiles: Files) {
-    // Initialize SoundTouch worklet first
-    await this.#initializeSoundTouchWorklet();
+    // Initialize SoundTouch worklet in the background (don't block track creation).
+    // The worklet is only needed for pitch-corrected tempo changes, not normal playback.
+    this.#initializeSoundTouchWorklet();
 
     const groupedFiles: GroupedFile = audioFiles.reduce(
       (acc, file) => {
@@ -111,7 +112,6 @@ export class AudioManager {
           this.#context,
           filteredAudioBuffers,
           this.#handleTrackEnded.bind(this),
-          this.#soundTouchWorklet,
         );
       }),
     );
@@ -154,6 +154,14 @@ export class AudioManager {
 
       // Connect the worklet to destination so audio can flow through
       this.#soundTouchWorklet.connect(this.#context.destination);
+
+      // If tempo was already changed before the worklet finished loading,
+      // route the tracks through the worklet now
+      if (this.#tempoConfig.tempo !== 1.0) {
+        Object.values(this.#tracks).forEach(track => {
+          track.setWorkletRouting(this.#soundTouchWorklet);
+        });
+      }
     } catch (error) {
       console.error('Failed to initialize SoundTouch worklet:', error);
       this.#soundTouchWorklet = null;
@@ -182,6 +190,7 @@ export class AudioManager {
       this.#lastTempoChangeEffectiveTime = this.#effectivePlayTime;
     }
 
+    const previousTempo = this.#tempoConfig.tempo;
     this.#tempoConfig.tempo = tempo;
 
     if (this.#soundTouchWorklet) {
@@ -194,6 +203,18 @@ export class AudioManager {
       if (rateParam)
         rateParam.setValueAtTime(1.0 / tempo, this.#context.currentTime);
       if (pitchParam) pitchParam.setValueAtTime(1.0, this.#context.currentTime);
+
+      // Route audio through the worklet only when tempo != 1.0 (for pitch correction).
+      // At tempo 1.0, bypass the worklet and connect directly to destination.
+      const wasUsingWorklet = previousTempo !== 1.0;
+      const shouldUseWorklet = tempo !== 1.0;
+      if (wasUsingWorklet !== shouldUseWorklet) {
+        Object.values(this.#tracks).forEach(track => {
+          track.setWorkletRouting(
+            shouldUseWorklet ? this.#soundTouchWorklet : null,
+          );
+        });
+      }
     }
 
     // Update all tracks to use the new tempo (drive playbackRate at the source)
@@ -409,23 +430,16 @@ class AudioTrack {
     context: AudioContext,
     audioBuffers: AudioBuffer[],
     onSongEnded: () => void,
-    workletNode?: AudioWorkletNode | null,
   ) {
     this.#context = context;
     this.#audioBuffers = audioBuffers;
     this.#onSongEnded = onSongEnded;
-    this.#workletNode = workletNode || null;
 
     this.#gainNodes = new Array(audioBuffers.length).fill(null).map(() => {
       const gainNode = this.#context.createGain();
-
-      // Connect through the worklet if available, otherwise directly to destination
-      if (this.#workletNode) {
-        gainNode.connect(this.#workletNode);
-      } else {
-        gainNode.connect(this.#context.destination);
-      }
-
+      // Connect directly to destination by default (bypass worklet).
+      // setWorkletRouting() can redirect through the worklet later.
+      gainNode.connect(this.#context.destination);
       return gainNode;
     });
 
@@ -434,6 +448,22 @@ class AudioTrack {
     );
 
     this.volume = 1;
+  }
+
+  /**
+   * Switch gain nodes between routing through the worklet (for pitch-corrected
+   * tempo changes) and routing directly to the AudioContext destination.
+   */
+  setWorkletRouting(workletNode: AudioWorkletNode | null) {
+    this.#workletNode = workletNode;
+    this.#gainNodes.forEach(gainNode => {
+      gainNode.disconnect();
+      if (workletNode) {
+        gainNode.connect(workletNode);
+      } else {
+        gainNode.connect(this.#context.destination);
+      }
+    });
   }
 
   get ended() {


### PR DESCRIPTION
## Summary

- **Root cause:** The SoundTouch AudioWorklet (added in d4137f5 on Mar 18) routes ALL audio through the worklet processor, even at normal speed. On mobile browsers, the worklet can fail silently during processing (its `process()` method has a `return false` path that kills the audio pipeline), causing no audio output. The worklet also blocked track creation with `await`, meaning if the worklet hung on mobile, the AudioManager would never initialize.
- **Fix:** Audio tracks now connect directly to `AudioContext.destination` by default, bypassing the worklet entirely. The worklet is only engaged when the user actually changes tempo from 1.0 (for pitch correction). The worklet also loads in the background instead of blocking track creation.
- Both the play button and clicking measures to play were affected since both depend on `audioManagerRef.current` being initialized.

## Test plan

- [ ] Verify audio plays on mobile (iOS Safari, Android Chrome) via play button
- [ ] Verify clicking a measure starts audio playback on mobile
- [ ] Verify audio plays on desktop
- [ ] Verify tempo/speed changes still work with pitch correction on desktop
- [ ] Verify returning tempo to 1.0 bypasses the worklet again

https://claude.ai/code/session_016xkMTht3c2HtK7HnkQYEyv