### PR TITLE
build: run jest with NODE_ENV=test --ci so React.act exists in CI

### DIFF
--- a/spotify-clonehero-next/package.json
+++ b/spotify-clonehero-next/package.json
@@ -7,7 +7,7 @@
     "dev:guarded": "scripts/dev-guarded.sh",
     "dev:webpack": "next dev --webpack",
     "dev:webpack:guarded": "DEV_CMD='yarn dev:webpack' scripts/dev-guarded.sh",
-    "build": "yarn run jest && next build",
+    "build": "NODE_ENV=test jest --ci && next build",
     "start": "next start",
     "lint": "eslint . && prettier --check .",
     "format": "prettier --write .",


### PR DESCRIPTION
## Summary
- Vercel invokes `yarn build` with `NODE_ENV=production`, which Jest inherits.
- React 19's production build strips `React.act`; `@testing-library/react@16` (added with the new capability-gate tests in #20) calls into it from `render`/`cleanup`, blowing up CI with `TypeError: React.act is not a function`.
- Override `NODE_ENV=test` in the build script so jest loads React's dev build, and pass `--ci` (canonical CI flag).

## Test plan
- [x] `yarn jest` locally: 35/35 suites, 611/611 pass.
- [x] `NODE_ENV=production sh -c 'NODE_ENV=test ./node_modules/.bin/jest --ci'` (simulates Vercel's env + new script): 35/35, 611/611 pass.
- [x] `NODE_ENV=production yarn jest` (the failing CI scenario before this fix): 8 failures in capability-gates, confirming the env-var override is what actually fixes it.
- [ ] Vercel preview deployment goes green.