### PR TITLE
Add OG/metadata image for the /sng route

### DIFF
--- a/spotify-clonehero-next/app/sng/opengraph-image.tsx
+++ b/spotify-clonehero-next/app/sng/opengraph-image.tsx
@@ -4,9 +4,30 @@ export const alt = 'SNG File Manager';
 export const size = {width: 1200, height: 630};
 export const contentType = 'image/png';
 
-// The files that typically make up a Clone Hero package, shown collapsing
-// into a single .sng (and convertible to .zip).
+// The files that typically make up a Clone Hero package.
 const PACKAGE_FILES = ['notes.chart', 'song.opus', 'album.png'];
+
+const square = {
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  width: 168,
+  height: 168,
+  fontSize: 46,
+  fontWeight: 700,
+  fontFamily: 'monospace',
+  color: 'white',
+  background: 'rgba(255,255,255,0.08)',
+  border: '1px solid rgba(255,255,255,0.18)',
+  borderRadius: 22,
+} as const;
+
+const arrow = {
+  display: 'flex',
+  flexShrink: 0,
+  fontSize: 56,
+  color: 'rgba(255,255,255,0.5)',
+} as const;
 
 export default function OpengraphImage() {
   return new ImageResponse(
@@ -61,70 +82,40 @@ export default function OpengraphImage() {
           browser.
         </div>
 
-        {/* loose files → .sng / .zip */}
+        {/* .sng → its files → .sng / .zip */}
         <div
           style={{
             display: 'flex',
             flexShrink: 0,
             alignItems: 'center',
-            gap: 28,
+            gap: 24,
           }}>
-          <div style={{display: 'flex', flexDirection: 'column', gap: 12}}>
+          <div style={square}>.sng</div>
+
+          <div style={arrow}>→</div>
+
+          {/* the files inside the package */}
+          <div
+            style={{
+              ...square,
+              flexDirection: 'column',
+              gap: 10,
+              fontSize: 20,
+              fontWeight: 400,
+              color: 'rgba(255,255,255,0.82)',
+            }}>
             {PACKAGE_FILES.map(name => (
-              <div
-                key={name}
-                style={{
-                  display: 'flex',
-                  fontSize: 26,
-                  fontFamily: 'monospace',
-                  color: 'rgba(255,255,255,0.82)',
-                  background: 'rgba(255,255,255,0.05)',
-                  border: '1px solid rgba(255,255,255,0.12)',
-                  borderRadius: 12,
-                  padding: '10px 20px',
-                }}>
+              <div key={name} style={{display: 'flex'}}>
                 {name}
               </div>
             ))}
           </div>
 
-          <div
-            style={{
-              display: 'flex',
-              fontSize: 64,
-              color: 'rgba(255,255,255,0.5)',
-              margin: '0 8px',
-            }}>
-            →
-          </div>
+          <div style={arrow}>→</div>
 
           <div style={{display: 'flex', gap: 22}}>
-            {['.sng', '.zip'].map(ext => (
-              <div
-                key={ext}
-                style={{
-                  display: 'flex',
-                  alignItems: 'center',
-                  justifyContent: 'center',
-                  width: 168,
-                  height: 168,
-                  fontSize: 50,
-                  fontWeight: 700,
-                  fontFamily: 'monospace',
-                  color: 'white',
-                  background:
-                    ext === '.sng'
-                      ? 'linear-gradient(135deg, #f84b61 0%, #a5002c 100%)'
-                      : 'rgba(255,255,255,0.08)',
-                  border:
-                    ext === '.sng'
-                      ? 'none'
-                      : '1px solid rgba(255,255,255,0.18)',
-                  borderRadius: 22,
-                }}>
-                {ext}
-              </div>
-            ))}
+            <div style={square}>.sng</div>
+            <div style={square}>.zip</div>
           </div>
         </div>
       </div>

--- a/spotify-clonehero-next/app/sng/opengraph-image.tsx
+++ b/spotify-clonehero-next/app/sng/opengraph-image.tsx
@@ -1,0 +1,134 @@
+import {ImageResponse} from 'next/og';
+
+export const alt = 'SNG File Manager';
+export const size = {width: 1200, height: 630};
+export const contentType = 'image/png';
+
+// The files that typically make up a Clone Hero package, shown collapsing
+// into a single .sng (and convertible to .zip).
+const PACKAGE_FILES = ['notes.chart', 'song.opus', 'album.png'];
+
+export default function OpengraphImage() {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: '100%',
+          height: '100%',
+          display: 'flex',
+          flexDirection: 'column',
+          background:
+            'linear-gradient(135deg, #1a0a1f 0%, #2c0e36 50%, #0a0a14 100%)',
+          color: 'white',
+          fontFamily: 'system-ui, sans-serif',
+          padding: '64px 80px',
+        }}>
+        <div
+          style={{
+            display: 'flex',
+            flexShrink: 0,
+            fontSize: 26,
+            color: 'rgba(255,255,255,0.55)',
+            letterSpacing: '0.22em',
+            textTransform: 'uppercase',
+            marginBottom: 18,
+          }}>
+          Music Charts Tools
+        </div>
+        <div
+          style={{
+            display: 'flex',
+            flexShrink: 0,
+            fontSize: 92,
+            fontWeight: 800,
+            letterSpacing: '-0.03em',
+            lineHeight: 1.2,
+            marginBottom: 18,
+          }}>
+          SNG File Manager
+        </div>
+        <div
+          style={{
+            display: 'flex',
+            flexShrink: 0,
+            fontSize: 38,
+            color: 'rgba(255,255,255,0.78)',
+            maxWidth: 1000,
+            lineHeight: 1.3,
+            marginBottom: 44,
+          }}>
+          Create, inspect, and convert Clone Hero .sng packages — right in your
+          browser.
+        </div>
+
+        {/* loose files → .sng / .zip */}
+        <div
+          style={{
+            display: 'flex',
+            flexShrink: 0,
+            alignItems: 'center',
+            gap: 28,
+          }}>
+          <div style={{display: 'flex', flexDirection: 'column', gap: 12}}>
+            {PACKAGE_FILES.map(name => (
+              <div
+                key={name}
+                style={{
+                  display: 'flex',
+                  fontSize: 26,
+                  fontFamily: 'monospace',
+                  color: 'rgba(255,255,255,0.82)',
+                  background: 'rgba(255,255,255,0.05)',
+                  border: '1px solid rgba(255,255,255,0.12)',
+                  borderRadius: 12,
+                  padding: '10px 20px',
+                }}>
+                {name}
+              </div>
+            ))}
+          </div>
+
+          <div
+            style={{
+              display: 'flex',
+              fontSize: 64,
+              color: 'rgba(255,255,255,0.5)',
+              margin: '0 8px',
+            }}>
+            →
+          </div>
+
+          <div style={{display: 'flex', gap: 22}}>
+            {['.sng', '.zip'].map(ext => (
+              <div
+                key={ext}
+                style={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  width: 168,
+                  height: 168,
+                  fontSize: 50,
+                  fontWeight: 700,
+                  fontFamily: 'monospace',
+                  color: 'white',
+                  background:
+                    ext === '.sng'
+                      ? 'linear-gradient(135deg, #f84b61 0%, #a5002c 100%)'
+                      : 'rgba(255,255,255,0.08)',
+                  border:
+                    ext === '.sng'
+                      ? 'none'
+                      : '1px solid rgba(255,255,255,0.18)',
+                  borderRadius: 22,
+                }}>
+                {ext}
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    ),
+    size,
+  );
+}

--- a/spotify-clonehero-next/app/sng/opengraph-image.tsx
+++ b/spotify-clonehero-next/app/sng/opengraph-image.tsx
@@ -78,8 +78,7 @@ export default function OpengraphImage() {
             lineHeight: 1.3,
             marginBottom: 44,
           }}>
-          Create, inspect, and convert Clone Hero .sng packages — right in your
-          browser.
+          Create, inspect, and convert Clone Hero .sng packages.
         </div>
 
         {/* .sng → its files → .sng / .zip */}

--- a/spotify-clonehero-next/app/sng/opengraph-image.tsx
+++ b/spotify-clonehero-next/app/sng/opengraph-image.tsx
@@ -94,18 +94,21 @@ export default function OpengraphImage() {
 
           <div style={arrow}>→</div>
 
-          {/* the files inside the package */}
-          <div
-            style={{
-              ...square,
-              flexDirection: 'column',
-              gap: 10,
-              fontSize: 20,
-              fontWeight: 400,
-              color: 'rgba(255,255,255,0.82)',
-            }}>
+          {/* the files inside the package, each in its own rectangle */}
+          <div style={{display: 'flex', flexDirection: 'column', gap: 12}}>
             {PACKAGE_FILES.map(name => (
-              <div key={name} style={{display: 'flex'}}>
+              <div
+                key={name}
+                style={{
+                  display: 'flex',
+                  fontSize: 26,
+                  fontFamily: 'monospace',
+                  color: 'rgba(255,255,255,0.82)',
+                  background: 'rgba(255,255,255,0.05)',
+                  border: '1px solid rgba(255,255,255,0.12)',
+                  borderRadius: 12,
+                  padding: '10px 20px',
+                }}>
                 {name}
               </div>
             ))}


### PR DESCRIPTION
## What

Adds `app/sng/opengraph-image.tsx` so the **SNG File Manager** route has its own social-card / metadata image instead of falling back to the site-wide default.

It follows the same per-route `next/og` `ImageResponse` pattern as the other tools (`add-lyrics`, `spotify`, `sheet-music`, …): a 1200×630 PNG generated at request time, served for both Open Graph and Twitter. The art shows a Clone Hero package's loose files (`notes.chart`, `song.opus`, `album.png`) collapsing into a `.sng` (and a `.zip`), using the site's gradient theme.

## Preview

Generated locally by requesting `/sng/opengraph-image` (1200×630). Title / subtitle / file chips → `.sng` + `.zip` boxes, on the site gradient. Verified the route returns a valid PNG and the layout fits without overlap.

## Notes
- Branched off `main` (the SNG feature is already merged via #23).
- `tsc`, ESLint, and Prettier all clean. Avoids `<code>` / mixed text+element children (Satori-safe) and sizes content to fit 630px so nothing overlaps.

https://claude.ai/code/session_01GVLPAUDFdxnKwf6G3feDcB