### PR TITLE
Fix /add-lyrics export to preserve manual timing edits

### DIFF
--- a/spotify-clonehero-next/app/add-lyrics/AddLyricsClient.tsx
+++ b/spotify-clonehero-next/app/add-lyrics/AddLyricsClient.tsx
@@ -33,8 +33,8 @@ import {
   writeChartFolder,
   type ChartDocument,
 } from '@/lib/chart-edit';
-import {exportAsZip, exportAsSng} from '@/lib/chart-export';
 import {downloadBlob} from '@/lib/download';
+import {buildChartExport} from './export-chart';
 import type {AlignedSyllable} from '@/lib/lyrics-align/aligner';
 import {mixStemsToAudioBuffer} from '@/lib/audio-pipeline/lyrics-audio';
 import {runDemucsInWorker} from '@/lib/lyrics-align/demucs-client';
@@ -236,7 +236,6 @@ async function decodeAudioForWaveform(
 
 interface EditorData {
   chart: ParsedChart;
-  chartDoc: ChartDocument;
   audioManager: AudioManager;
   audioData?: Float32Array | undefined;
   audioChannels: number;
@@ -591,39 +590,21 @@ function LyricsAlignInner() {
   }, [chart, lyrics, updateAlignStep, alignSteps]);
 
   const handleDownload = useCallback(() => {
-    if (!chart || alignedSyllables.length === 0) return;
+    // Export the editor's live document. It starts as the aligned doc and
+    // every highway edit (lyric drags, phrase resizes, text changes) is
+    // dispatched onto it, so it is the only doc that carries the user's
+    // manual fixes. Re-deriving from `chart.chartDoc` would discard them.
+    const doc = state.chartDoc;
+    if (!chart || !doc) return;
 
     try {
-      const doc = applyAlignedLyricsToDoc(chart.chartDoc, alignedSyllables);
+      const {blob, fileName} = buildChartExport(
+        doc,
+        chart.sourceFormat,
+        chart.originalName,
+      );
 
-      // Write chart back to files
-      const chartFiles = writeChartFolder(doc);
-
-      // writeChartFolder emits notes.{chart,mid} + song.ini + every asset
-      // from doc.assets (audio stems, album art, etc.) and skips any
-      // chart-like file in the asset list. That covers the full export —
-      // no need to merge in chart.rawFiles separately.
-      const exportFiles = chartFiles.map(f => ({
-        fileName: f.fileName,
-        data: f.data,
-      }));
-
-      // Package in original format, using the original filename
-      const ext = chart.sourceFormat === 'sng' ? '.sng' : '.zip';
-
-      let blob: Blob;
-      if (chart.sourceFormat === 'sng') {
-        const sngBytes = exportAsSng(exportFiles);
-        blob = new Blob([sngBytes as Uint8Array<ArrayBuffer>], {
-          type: 'application/octet-stream',
-        });
-      } else {
-        blob = exportAsZip(exportFiles);
-      }
-
-      const filename = chart.originalName + ext;
-
-      downloadBlob(blob, filename);
+      downloadBlob(blob, fileName);
 
       const manualMoveCount = state.undoStack.filter(
         cmd =>
@@ -639,7 +620,7 @@ function LyricsAlignInner() {
     } catch (e) {
       toast.error(e instanceof Error ? e.message : 'Export failed');
     }
-  }, [chart, alignedSyllables, state.undoStack]);
+  }, [chart, state.chartDoc, state.undoStack]);
 
   const showEditor = status === 'done' && alignedLines.length > 0;
 
@@ -693,7 +674,6 @@ function LyricsAlignInner() {
 
         setEditorData({
           chart: nextDoc.parsedChart as ParsedChart,
-          chartDoc: nextDoc,
           audioManager,
           audioData: waveform?.interleaved,
           audioChannels: waveform?.channels ?? 1,
@@ -755,13 +735,16 @@ function LyricsAlignInner() {
   }, [chart]);
 
   const getChartText = useCallback(async (): Promise<string> => {
-    if (!editorData) throw new Error('No chart prepared');
-    const files = writeChartFolder(editorData.chartDoc);
+    // Same live-document rule as handleDownload: serialize what the editor
+    // currently holds, not the doc the editor was seeded with.
+    const doc = state.chartDoc;
+    if (!doc) throw new Error('No chart prepared');
+    const files = writeChartFolder(doc);
     const chartFile = files.find(f => f.fileName === 'notes.chart');
     if (!chartFile)
       throw new Error('writeChartFolder did not produce notes.chart');
     return new TextDecoder().decode(chartFile.data);
-  }, [editorData]);
+  }, [state.chartDoc]);
 
   if (showEditor && chart) {
     const md = chart.chartDoc.parsedChart.metadata;
@@ -802,7 +785,10 @@ function LyricsAlignInner() {
             }}>
             Re-enter lyrics
           </Button>
-          <Button size="sm" onClick={handleDownload}>
+          {/* Disabled until the editor is prepared: until then the session
+              doc is still the previous alignment's (or nothing at all), and
+              exporting it would hand back the wrong chart. */}
+          <Button size="sm" onClick={handleDownload} disabled={!editorData}>
             <Download className="h-4 w-4 mr-1" />
             Download .{chart.sourceFormat === 'sng' ? 'sng' : 'zip'}
           </Button>

--- a/spotify-clonehero-next/app/add-lyrics/AddLyricsClient.tsx
+++ b/spotify-clonehero-next/app/add-lyrics/AddLyricsClient.tsx
@@ -28,11 +28,7 @@ import {
   findAudioFiles,
   type Files,
 } from '@/lib/preview/chorus-chart-processing';
-import {
-  readChart,
-  writeChartFolder,
-  type ChartDocument,
-} from '@/lib/chart-edit';
+import {readChart, type ChartDocument} from '@/lib/chart-edit';
 import {downloadBlob} from '@/lib/download';
 import {buildChartExport} from './export-chart';
 import type {AlignedSyllable} from '@/lib/lyrics-align/aligner';
@@ -234,8 +230,13 @@ async function decodeAudioForWaveform(
 // Page Component
 // ---------------------------------------------------------------------------
 
+/**
+ * The non-chart half of the editor view: the audio and waveform the
+ * ChartEditor needs alongside the document. The chart itself is read from
+ * the editor session (`state.chartDoc`) so it stays live as the user edits;
+ * nothing chart-shaped is snapshotted here.
+ */
 interface EditorData {
-  chart: ParsedChart;
   audioManager: AudioManager;
   audioData?: Float32Array | undefined;
   audioChannels: number;
@@ -673,7 +674,6 @@ function LyricsAlignInner() {
         dispatch({type: 'SET_CHART_DOC', chartDoc: nextDoc});
 
         setEditorData({
-          chart: nextDoc.parsedChart as ParsedChart,
           audioManager,
           audioData: waveform?.interleaved,
           audioChannels: waveform?.channels ?? 1,
@@ -734,17 +734,11 @@ function LyricsAlignInner() {
     } as ChartResponseEncore;
   }, [chart]);
 
-  const getChartText = useCallback(async (): Promise<string> => {
-    // Same live-document rule as handleDownload: serialize what the editor
-    // currently holds, not the doc the editor was seeded with.
-    const doc = state.chartDoc;
-    if (!doc) throw new Error('No chart prepared');
-    const files = writeChartFolder(doc);
-    const chartFile = files.find(f => f.fileName === 'notes.chart');
-    if (!chartFile)
-      throw new Error('writeChartFolder did not produce notes.chart');
-    return new TextDecoder().decode(chartFile.data);
-  }, [state.chartDoc]);
+  // The chart the editor renders, read live from the session so highway
+  // edits reach every consumer (sheet-music pane, section list) rather than
+  // only the parts the scene reconciler redraws.
+  const editorChart = (state.chartDoc?.parsedChart ??
+    null) as ParsedChart | null;
 
   if (showEditor && chart) {
     const md = chart.chartDoc.parsedChart.metadata;
@@ -831,19 +825,18 @@ function LyricsAlignInner() {
           </DialogContent>
         </Dialog>
         <div className="flex-1 min-h-0">
-          {editorData && cloneHeroMetadata ? (
+          {editorData && cloneHeroMetadata && editorChart ? (
             <ChartEditor
               metadata={cloneHeroMetadata}
-              chart={editorData.chart}
+              chart={editorChart}
               audioManager={editorData.audioManager}
               audioData={editorData.audioData}
               audioChannels={editorData.audioChannels}
               durationSeconds={editorData.durationSeconds}
-              sections={editorData.chart.sections}
+              sections={editorChart.sections}
               songName={songName}
               artistName={artistName}
               charterName={charterName}
-              getChartText={getChartText}
               hideHeader
             />
           ) : (

--- a/spotify-clonehero-next/app/add-lyrics/__tests__/export-chart.test.ts
+++ b/spotify-clonehero-next/app/add-lyrics/__tests__/export-chart.test.ts
@@ -16,7 +16,7 @@ import type {ChartDocument} from '@/lib/chart-edit';
 import {applyAlignedLyricsToDoc} from '@/lib/lyrics-align/apply-lyrics';
 import type {AlignedSyllable} from '@/lib/lyrics-align/aligner';
 import {makeFixtureDoc} from '@/components/chart-editor/__tests__/fixtures';
-import {buildChartExport, buildExportFiles} from '../export-chart';
+import {buildChartExport} from '../export-chart';
 
 const SYLLABLES: AlignedSyllable[] = [
   {text: 'hel', startMs: 1000, endMs: 1250, joinNext: true, newLine: true},
@@ -37,10 +37,12 @@ function lyricTicks(doc: ChartDocument): number[] {
   );
 }
 
-function notesChartText(doc: ChartDocument): string {
-  const file = buildExportFiles(doc).find(f => f.fileName === 'notes.chart');
-  if (!file) throw new Error('no notes.chart in export');
-  return strFromU8(file.data);
+/** Read a file out of an exported .zip blob. */
+async function readFromZip(blob: Blob, fileName: string): Promise<string> {
+  const zip = unzipSync(new Uint8Array(await blob.arrayBuffer()));
+  const file = zip[fileName];
+  if (!file) throw new Error(`${fileName} missing from export`);
+  return strFromU8(file);
 }
 
 /**
@@ -73,8 +75,8 @@ function moveFirstLyric(tickDelta: number): {
   return {seeded, edited};
 }
 
-describe('buildExportFiles', () => {
-  it('serializes the editor doc, keeping edits made after alignment', () => {
+describe('buildChartExport', () => {
+  it('serializes the editor doc, keeping edits made after alignment', async () => {
     const {seeded, edited} = moveFirstLyric(120);
 
     const seededTicks = lyricTicks(seeded);
@@ -82,51 +84,42 @@ describe('buildExportFiles', () => {
     expect(editedTicks).not.toEqual(seededTicks);
     expect(editedTicks).toContain(seededTicks[0] + 120);
 
-    // Every lyric tick the editor holds shows up in the written chart, and
+    // Every lyric tick the editor holds shows up in the downloaded chart, and
     // the pre-edit tick is gone — i.e. the download reflects the drag.
-    const text = notesChartText(edited);
+    const {blob} = buildChartExport(edited, 'zip', 'Song');
+    const text = await readFromZip(blob, 'notes.chart');
     for (const tick of editedTicks) {
       expect(text).toMatch(new RegExp(`^\\s*${tick} = E `, 'm'));
     }
     expect(text).not.toMatch(new RegExp(`^\\s*${seededTicks[0]} = E `, 'm'));
   });
 
-  it('emits notes.chart plus song.ini', () => {
-    const names = buildExportFiles(makeAlignedDoc()).map(f => f.fileName);
-    expect(names).toContain('notes.chart');
-    expect(names).toContain('song.ini');
-  });
-
-  it('leaves the source chart metadata alone', () => {
+  it('leaves the source chart identity alone', async () => {
     // This page round-trips somebody else's chart, so unlike the flows that
     // mint one (drum transcription, /difficulties) it must not stamp drum
     // ratings or rewrite the charter credit onto a chart that never had them.
     const doc = makeAlignedDoc();
     doc.parsedChart.metadata.charter = 'Original Charter';
 
-    const iniFile = buildExportFiles(doc).find(f => f.fileName === 'song.ini');
-    if (!iniFile) throw new Error('no song.ini in export');
-    const ini = strFromU8(iniFile.data);
+    const {blob} = buildChartExport(doc, 'zip', 'Song');
+    const ini = await readFromZip(blob, 'song.ini');
 
     expect(ini).toContain('charter = Original Charter');
     expect(ini).not.toMatch(/pro_drums/);
     expect(ini).not.toMatch(/diff_drums/);
   });
-});
 
-describe('buildChartExport', () => {
   it('packages a zip source as .zip under the original name', async () => {
-    const {edited} = moveFirstLyric(240);
-    const {blob, fileName} = buildChartExport(edited, 'zip', 'My Song');
+    const {blob, fileName} = buildChartExport(
+      makeAlignedDoc(),
+      'zip',
+      'My Song',
+    );
 
     expect(fileName).toBe('My Song.zip');
-
     const zip = unzipSync(new Uint8Array(await blob.arrayBuffer()));
     expect(Object.keys(zip)).toContain('notes.chart');
-    const movedTick = lyricTicks(edited)[0];
-    expect(strFromU8(zip['notes.chart'])).toMatch(
-      new RegExp(`^\\s*${movedTick} = E `, 'm'),
-    );
+    expect(Object.keys(zip)).toContain('song.ini');
   });
 
   it('packages a folder source as .zip', () => {

--- a/spotify-clonehero-next/app/add-lyrics/__tests__/export-chart.test.ts
+++ b/spotify-clonehero-next/app/add-lyrics/__tests__/export-chart.test.ts
@@ -1,0 +1,126 @@
+/**
+ * /add-lyrics export packaging.
+ *
+ * The regression these lock down: the Download button used to re-derive the
+ * exported chart by re-applying the aligner's output to the chart as loaded,
+ * so every manual timing fix the user made in the editor was dropped from the
+ * downloaded file. Export must serialize the editor session's live document.
+ */
+
+import {unzipSync, strFromU8} from 'fflate';
+import {EditorSession} from '@/lib/chart-editor-core';
+import {ADD_LYRICS_CAPABILITIES} from '@/components/chart-editor/capabilities';
+import {MoveEntitiesCommand} from '@/components/chart-editor/commands';
+import {lyricId} from '@/lib/chart-edit/helpers/lyrics';
+import type {ChartDocument} from '@/lib/chart-edit';
+import {applyAlignedLyricsToDoc} from '@/lib/lyrics-align/apply-lyrics';
+import type {AlignedSyllable} from '@/lib/lyrics-align/aligner';
+import {makeFixtureDoc} from '@/components/chart-editor/__tests__/fixtures';
+import {buildChartExport, buildExportFiles} from '../export-chart';
+
+const SYLLABLES: AlignedSyllable[] = [
+  {text: 'hel', startMs: 1000, endMs: 1250, joinNext: true, newLine: true},
+  {text: 'lo', startMs: 1250, endMs: 1500, joinNext: false, newLine: false},
+  {text: 'there', startMs: 2000, endMs: 2400, joinNext: false, newLine: true},
+];
+
+/** The doc the page hands the editor: chart as loaded + aligned lyrics. */
+function makeAlignedDoc(): ChartDocument {
+  return applyAlignedLyricsToDoc(makeFixtureDoc(), SYLLABLES);
+}
+
+function lyricTicks(doc: ChartDocument): number[] {
+  return (
+    doc.parsedChart.vocalTracks.parts['vocals']?.notePhrases.flatMap(p =>
+      p.lyrics.map(l => l.tick),
+    ) ?? []
+  );
+}
+
+function notesChartText(doc: ChartDocument): string {
+  const file = buildExportFiles(doc).find(f => f.fileName === 'notes.chart');
+  if (!file) throw new Error('no notes.chart in export');
+  return strFromU8(file.data);
+}
+
+/**
+ * Drive the same path the page does: seed the aligned doc, then move a lyric
+ * the way a highway drag would. Returns the session's live document.
+ */
+function moveFirstLyric(tickDelta: number): {
+  seeded: ChartDocument;
+  edited: ChartDocument;
+} {
+  const seeded = makeAlignedDoc();
+  const session = new EditorSession({}, ADD_LYRICS_CAPABILITIES);
+  session.dispatch({type: 'SET_CHART_DOC', chartDoc: seeded});
+
+  const firstTick = lyricTicks(seeded)[0];
+  const command = new MoveEntitiesCommand(
+    'lyric',
+    [lyricId(firstTick)],
+    tickDelta,
+    0,
+  );
+  session.dispatch({
+    type: 'EXECUTE_COMMAND',
+    command,
+    chartDoc: command.execute(seeded),
+  });
+
+  const edited = session.getState().chartDoc;
+  if (!edited) throw new Error('session lost the chart doc');
+  return {seeded, edited};
+}
+
+describe('buildExportFiles', () => {
+  it('serializes the editor doc, keeping edits made after alignment', () => {
+    const {seeded, edited} = moveFirstLyric(120);
+
+    const seededTicks = lyricTicks(seeded);
+    const editedTicks = lyricTicks(edited);
+    expect(editedTicks).not.toEqual(seededTicks);
+    expect(editedTicks).toContain(seededTicks[0] + 120);
+
+    // Every lyric tick the editor holds shows up in the written chart, and
+    // the pre-edit tick is gone — i.e. the download reflects the drag.
+    const text = notesChartText(edited);
+    for (const tick of editedTicks) {
+      expect(text).toMatch(new RegExp(`^\\s*${tick} = E `, 'm'));
+    }
+    expect(text).not.toMatch(new RegExp(`^\\s*${seededTicks[0]} = E `, 'm'));
+  });
+
+  it('emits notes.chart plus song.ini', () => {
+    const names = buildExportFiles(makeAlignedDoc()).map(f => f.fileName);
+    expect(names).toContain('notes.chart');
+    expect(names).toContain('song.ini');
+  });
+});
+
+describe('buildChartExport', () => {
+  it('packages a zip source as .zip under the original name', async () => {
+    const {edited} = moveFirstLyric(240);
+    const {blob, fileName} = buildChartExport(edited, 'zip', 'My Song');
+
+    expect(fileName).toBe('My Song.zip');
+
+    const zip = unzipSync(new Uint8Array(await blob.arrayBuffer()));
+    expect(Object.keys(zip)).toContain('notes.chart');
+    const movedTick = lyricTicks(edited)[0];
+    expect(strFromU8(zip['notes.chart'])).toMatch(
+      new RegExp(`^\\s*${movedTick} = E `, 'm'),
+    );
+  });
+
+  it('packages a folder source as .zip', () => {
+    const {fileName} = buildChartExport(makeAlignedDoc(), 'folder', 'Song');
+    expect(fileName).toBe('Song.zip');
+  });
+
+  it('packages an sng source as .sng', () => {
+    const {blob, fileName} = buildChartExport(makeAlignedDoc(), 'sng', 'Song');
+    expect(fileName).toBe('Song.sng');
+    expect(blob.size).toBeGreaterThan(0);
+  });
+});

--- a/spotify-clonehero-next/app/add-lyrics/__tests__/export-chart.test.ts
+++ b/spotify-clonehero-next/app/add-lyrics/__tests__/export-chart.test.ts
@@ -96,6 +96,22 @@ describe('buildExportFiles', () => {
     expect(names).toContain('notes.chart');
     expect(names).toContain('song.ini');
   });
+
+  it('leaves the source chart metadata alone', () => {
+    // This page round-trips somebody else's chart, so unlike the flows that
+    // mint one (drum transcription, /difficulties) it must not stamp drum
+    // ratings or rewrite the charter credit onto a chart that never had them.
+    const doc = makeAlignedDoc();
+    doc.parsedChart.metadata.charter = 'Original Charter';
+
+    const iniFile = buildExportFiles(doc).find(f => f.fileName === 'song.ini');
+    if (!iniFile) throw new Error('no song.ini in export');
+    const ini = strFromU8(iniFile.data);
+
+    expect(ini).toContain('charter = Original Charter');
+    expect(ini).not.toMatch(/pro_drums/);
+    expect(ini).not.toMatch(/diff_drums/);
+  });
 });
 
 describe('buildChartExport', () => {

--- a/spotify-clonehero-next/app/add-lyrics/export-chart.ts
+++ b/spotify-clonehero-next/app/add-lyrics/export-chart.ts
@@ -6,37 +6,19 @@
  * makes (lyric drags, phrase resizes, text changes) is dispatched onto it.
  * Serializing anything else — the doc as loaded, or a snapshot captured when
  * the editor was prepared — silently drops the user's manual timing fixes.
- *
- * Deliberately not built on `assembleChartFiles`: that helper exists for
- * flows that MINT a chart (drum transcription, /difficulties), so it stamps
- * `pro_drums`/`diff_drums` and rewrites name/artist/charter/song_length from
- * caller-supplied metadata. This page round-trips somebody else's chart —
- * a guitar-only chart must not come back advertising rated pro drums — so it
- * writes the document as-is and reuses only the container step.
  */
 
-import {writeChartFolder, type ChartDocument} from '@/lib/chart-edit';
-import {packageChartFiles, type PackageFormat} from '@/lib/chart-export';
+import type {ChartDocument} from '@/lib/chart-edit';
+import {
+  assembleChartFiles,
+  packageChartFiles,
+  type PackageFormat,
+} from '@/lib/chart-export';
 import type {SourceFormat} from '@/components/chart-picker/chart-file-readers';
-import type {File as FileEntry} from '@eliwhite/scan-chart';
 
 export interface ChartExport {
   blob: Blob;
   fileName: string;
-}
-
-/**
- * Serialize the chart document to the file list that goes into the package.
- *
- * `writeChartFolder` emits notes.{chart,mid} + song.ini + every asset from
- * `doc.assets` (audio stems, album art, etc.) and skips any chart-like file
- * in the asset list, so this covers the full export on its own.
- */
-export function buildExportFiles(doc: ChartDocument): FileEntry[] {
-  return writeChartFolder(doc).map(f => ({
-    fileName: f.fileName,
-    data: f.data,
-  }));
 }
 
 /** The container a chart loaded from `sourceFormat` is handed back in. A
@@ -49,10 +31,12 @@ function packageFormatFor(sourceFormat: SourceFormat): PackageFormat {
  * Package the chart document in the format it was loaded from, keeping the
  * original name.
  *
- * The name is the user's own file name rather than `chartPackageFileName`'s
- * `Artist - Song (Charter)` convention: this is the file they handed us,
- * coming back with lyrics in it, and renaming it would strip whatever
- * organization their library already has.
+ * Assembles in round-trip mode (no `metadata`), so the chart's own identity
+ * and ratings survive: this page edits somebody else's chart rather than
+ * minting one. The name is likewise the user's own file name rather than
+ * `chartPackageFileName`'s `Artist - Song (Charter)` convention — this is the
+ * file they handed us, coming back with lyrics in it, and renaming it would
+ * strip whatever organization their library already has.
  */
 export function buildChartExport(
   doc: ChartDocument,
@@ -60,7 +44,7 @@ export function buildChartExport(
   originalName: string,
 ): ChartExport {
   const {blob, extension} = packageChartFiles(
-    buildExportFiles(doc),
+    assembleChartFiles({chartDoc: doc}),
     packageFormatFor(sourceFormat),
   );
 

--- a/spotify-clonehero-next/app/add-lyrics/export-chart.ts
+++ b/spotify-clonehero-next/app/add-lyrics/export-chart.ts
@@ -6,10 +6,17 @@
  * makes (lyric drags, phrase resizes, text changes) is dispatched onto it.
  * Serializing anything else — the doc as loaded, or a snapshot captured when
  * the editor was prepared — silently drops the user's manual timing fixes.
+ *
+ * Deliberately not built on `assembleChartFiles`: that helper exists for
+ * flows that MINT a chart (drum transcription, /difficulties), so it stamps
+ * `pro_drums`/`diff_drums` and rewrites name/artist/charter/song_length from
+ * caller-supplied metadata. This page round-trips somebody else's chart —
+ * a guitar-only chart must not come back advertising rated pro drums — so it
+ * writes the document as-is and reuses only the container step.
  */
 
 import {writeChartFolder, type ChartDocument} from '@/lib/chart-edit';
-import {exportAsZip, exportAsSng} from '@/lib/chart-export';
+import {packageChartFiles, type PackageFormat} from '@/lib/chart-export';
 import type {SourceFormat} from '@/components/chart-picker/chart-file-readers';
 import type {File as FileEntry} from '@eliwhite/scan-chart';
 
@@ -32,27 +39,30 @@ export function buildExportFiles(doc: ChartDocument): FileEntry[] {
   }));
 }
 
+/** The container a chart loaded from `sourceFormat` is handed back in. A
+ *  `.sng` round-trips as `.sng`; folders and `.zip` both leave as `.zip`. */
+function packageFormatFor(sourceFormat: SourceFormat): PackageFormat {
+  return sourceFormat === 'sng' ? 'sng' : 'zip';
+}
+
 /**
  * Package the chart document in the format it was loaded from, keeping the
- * original name. `.sng` sources round-trip as `.sng`; folders and `.zip`
- * sources both come back as `.zip`.
+ * original name.
+ *
+ * The name is the user's own file name rather than `chartPackageFileName`'s
+ * `Artist - Song (Charter)` convention: this is the file they handed us,
+ * coming back with lyrics in it, and renaming it would strip whatever
+ * organization their library already has.
  */
 export function buildChartExport(
   doc: ChartDocument,
   sourceFormat: SourceFormat,
   originalName: string,
 ): ChartExport {
-  const files = buildExportFiles(doc);
+  const {blob, extension} = packageChartFiles(
+    buildExportFiles(doc),
+    packageFormatFor(sourceFormat),
+  );
 
-  if (sourceFormat === 'sng') {
-    const sngBytes = exportAsSng(files);
-    return {
-      blob: new Blob([sngBytes as Uint8Array<ArrayBuffer>], {
-        type: 'application/octet-stream',
-      }),
-      fileName: `${originalName}.sng`,
-    };
-  }
-
-  return {blob: exportAsZip(files), fileName: `${originalName}.zip`};
+  return {blob, fileName: `${originalName}.${extension}`};
 }

--- a/spotify-clonehero-next/app/add-lyrics/export-chart.ts
+++ b/spotify-clonehero-next/app/add-lyrics/export-chart.ts
@@ -1,0 +1,58 @@
+/**
+ * Packaging for /add-lyrics' "Download" button.
+ *
+ * The doc handed in must be the chart editor's live document
+ * (`state.chartDoc`) — the aligner seeds it, and every highway edit the user
+ * makes (lyric drags, phrase resizes, text changes) is dispatched onto it.
+ * Serializing anything else — the doc as loaded, or a snapshot captured when
+ * the editor was prepared — silently drops the user's manual timing fixes.
+ */
+
+import {writeChartFolder, type ChartDocument} from '@/lib/chart-edit';
+import {exportAsZip, exportAsSng} from '@/lib/chart-export';
+import type {SourceFormat} from '@/components/chart-picker/chart-file-readers';
+import type {File as FileEntry} from '@eliwhite/scan-chart';
+
+export interface ChartExport {
+  blob: Blob;
+  fileName: string;
+}
+
+/**
+ * Serialize the chart document to the file list that goes into the package.
+ *
+ * `writeChartFolder` emits notes.{chart,mid} + song.ini + every asset from
+ * `doc.assets` (audio stems, album art, etc.) and skips any chart-like file
+ * in the asset list, so this covers the full export on its own.
+ */
+export function buildExportFiles(doc: ChartDocument): FileEntry[] {
+  return writeChartFolder(doc).map(f => ({
+    fileName: f.fileName,
+    data: f.data,
+  }));
+}
+
+/**
+ * Package the chart document in the format it was loaded from, keeping the
+ * original name. `.sng` sources round-trip as `.sng`; folders and `.zip`
+ * sources both come back as `.zip`.
+ */
+export function buildChartExport(
+  doc: ChartDocument,
+  sourceFormat: SourceFormat,
+  originalName: string,
+): ChartExport {
+  const files = buildExportFiles(doc);
+
+  if (sourceFormat === 'sng') {
+    const sngBytes = exportAsSng(files);
+    return {
+      blob: new Blob([sngBytes as Uint8Array<ArrayBuffer>], {
+        type: 'application/octet-stream',
+      }),
+      fileName: `${originalName}.sng`,
+    };
+  }
+
+  return {blob: exportAsZip(files), fileName: `${originalName}.zip`};
+}

--- a/spotify-clonehero-next/app/difficulties/ExportChartDialog.tsx
+++ b/spotify-clonehero-next/app/difficulties/ExportChartDialog.tsx
@@ -26,15 +26,13 @@ import {readChart} from '@/lib/chart-edit';
 import {
   assembleChartFiles,
   chartPackageFileName,
-  exportAsSng,
-  exportAsZip,
+  packageChartFiles,
+  type PackageFormat,
 } from '@/lib/chart-export';
 import {downloadBlob} from '@/lib/download';
 import {mergeOursTiersIntoChart} from '@/lib/drum-difficulty/exportChart';
 import type {Tier} from '@/lib/drum-difficulty/toRenderableTrack';
 import type {Track} from '@/lib/preview/highway/types';
-
-type PackageFormat = 'zip' | 'sng';
 
 export interface ExportChartDialogProps {
   /** The originally-uploaded files, re-read fresh at export time so the
@@ -81,18 +79,7 @@ export default function ExportChartDialog({
           : {}),
       });
 
-      let blob: Blob;
-      let extension: string;
-      if (packageFormat === 'sng') {
-        const sngBytes = exportAsSng(fileEntries);
-        blob = new Blob([sngBytes as Uint8Array<ArrayBuffer>], {
-          type: 'application/octet-stream',
-        });
-        extension = 'sng';
-      } else {
-        blob = exportAsZip(fileEntries);
-        extension = 'zip';
-      }
+      const {blob, extension} = packageChartFiles(fileEntries, packageFormat);
 
       downloadBlob(blob, chartPackageFileName(cleanMetadata, extension));
       toast.success('Chart exported with Ours’ Hard/Medium/Easy tracks');

--- a/spotify-clonehero-next/components/chart-editor/ExportDialog.tsx
+++ b/spotify-clonehero-next/components/chart-editor/ExportDialog.tsx
@@ -25,11 +25,11 @@ import {Label} from '@/components/ui/label';
 import {Switch} from '@/components/ui/switch';
 
 import {
-  exportAsZip,
-  exportAsSng,
   assembleChartFiles,
   chartPackageFileName,
+  packageChartFiles,
   transcodeAudioFilesToOpus,
+  type PackageFormat,
 } from '@/lib/chart-export';
 import {downloadBlob} from '@/lib/download';
 
@@ -136,8 +136,6 @@ export interface AssetFile {
   fileName: string;
   data: Uint8Array;
 }
-
-type PackageFormat = 'zip' | 'sng';
 
 // ---------------------------------------------------------------------------
 // Component
@@ -265,20 +263,7 @@ export default function ExportDialog({
       });
 
       // 4. Package as ZIP or SNG
-      let blob: Blob;
-      let extension: string;
-
-      if (packageFormat === 'sng') {
-        // exportAsSng extracts song.ini into SNG header metadata automatically
-        const sngBytes = exportAsSng(fileEntries);
-        blob = new Blob([sngBytes as Uint8Array<ArrayBuffer>], {
-          type: 'application/octet-stream',
-        });
-        extension = 'sng';
-      } else {
-        blob = exportAsZip(fileEntries);
-        extension = 'zip';
-      }
+      const {blob, extension} = packageChartFiles(fileEntries, packageFormat);
 
       // 5. Trigger browser download, named `Artist - Song (Charter)`
       downloadBlob(blob, chartPackageFileName(cleanMetadata, extension));

--- a/spotify-clonehero-next/lib/chart-export/__tests__/assemble-roundtrip.test.ts
+++ b/spotify-clonehero-next/lib/chart-export/__tests__/assemble-roundtrip.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Tests for `assembleChartFiles`'s round-trip mode — `metadata` omitted.
+ *
+ * Flows that MINT a chart (drum transcription, /difficulties) supply
+ * metadata and get the chart stamped with that identity plus drum ratings.
+ * Flows that EDIT somebody else's chart and hand it back (/add-lyrics) omit
+ * it, and must get the document's own metadata through untouched: stamping
+ * `pro_drums` onto a guitar-only chart, or renaming its charter, would
+ * corrupt a chart the user is merely round-tripping.
+ */
+
+import {describe, test, expect} from '@jest/globals';
+import type {ChartDocument} from '@eliwhite/scan-chart';
+
+import {createEmptyChart} from '@/lib/chart-edit';
+
+import {assembleChartFiles} from '../assemble';
+
+function chartDoc(
+  overrides: Partial<ChartDocument['parsedChart']['metadata']> = {},
+): ChartDocument {
+  const parsedChart = createEmptyChart();
+  return {
+    parsedChart: {
+      ...parsedChart,
+      metadata: {
+        ...parsedChart.metadata,
+        name: 'Original Name',
+        artist: 'Original Artist',
+        charter: 'Original Charter',
+        genre: 'Rock',
+        year: '2024',
+        ...overrides,
+      },
+    },
+    assets: [],
+  };
+}
+
+function songIniText(entries: {fileName: string; data: Uint8Array}[]): string {
+  const songIni = entries.find(e => e.fileName === 'song.ini');
+  if (!songIni) throw new Error('assembleChartFiles produced no song.ini');
+  return new TextDecoder().decode(songIni.data);
+}
+
+describe('assembleChartFiles round-trip mode (no metadata)', () => {
+  test('ships the document’s own identity untouched', () => {
+    const ini = songIniText(assembleChartFiles({chartDoc: chartDoc()}));
+
+    expect(ini).toContain('name = Original Name');
+    expect(ini).toContain('artist = Original Artist');
+    expect(ini).toContain('charter = Original Charter');
+    expect(ini).toContain('genre = Rock');
+  });
+
+  test('does not declare drum ratings the chart never had', () => {
+    const ini = songIniText(assembleChartFiles({chartDoc: chartDoc()}));
+
+    expect(ini).not.toMatch(/pro_drums/);
+    expect(ini).not.toMatch(/diff_drums/);
+  });
+
+  test('leaves song_length alone rather than recomputing it', () => {
+    const ini = songIniText(
+      assembleChartFiles({chartDoc: chartDoc({song_length: 12345})}),
+    );
+
+    expect(ini).toContain('song_length = 12345');
+  });
+
+  test('does not mutate the caller’s document', () => {
+    const doc = chartDoc();
+    assembleChartFiles({chartDoc: doc});
+
+    expect(doc.parsedChart.metadata.charter).toBe('Original Charter');
+    expect(doc.parsedChart.metadata.pro_drums).toBeUndefined();
+  });
+
+  test('still appends audio sources and extra assets', () => {
+    const entries = assembleChartFiles({
+      chartDoc: chartDoc(),
+      audioSources: [{fileName: 'song.opus', data: new Uint8Array([1, 2])}],
+      extraAssets: [{fileName: 'album.png', data: new Uint8Array([3, 4])}],
+    });
+
+    const names = entries.map(e => e.fileName);
+    expect(names).toContain('song.opus');
+    expect(names).toContain('album.png');
+  });
+
+  test('supplying metadata still stamps identity and ratings', () => {
+    const ini = songIniText(
+      assembleChartFiles({
+        chartDoc: chartDoc(),
+        metadata: {name: 'New', artist: 'New Artist', charter: 'New Charter'},
+      }),
+    );
+
+    expect(ini).toContain('name = New');
+    expect(ini).toContain('charter = New Charter');
+    expect(ini).toMatch(/pro_drums/);
+    expect(ini).toMatch(/diff_drums/);
+  });
+});

--- a/spotify-clonehero-next/lib/chart-export/__tests__/assemble-roundtrip.test.ts
+++ b/spotify-clonehero-next/lib/chart-export/__tests__/assemble-roundtrip.test.ts
@@ -88,6 +88,20 @@ describe('assembleChartFiles round-trip mode (no metadata)', () => {
     expect(names).toContain('album.png');
   });
 
+  test('rejects a half-configured stamp at compile time', () => {
+    // `songLengthMs` has nothing to stamp onto without `metadata`. The union
+    // makes that a type error rather than a silently dropped option — this
+    // assertion fails `pnpm typecheck` if the guarantee ever regresses.
+    const options = {
+      chartDoc: chartDoc({song_length: 999}),
+      songLengthMs: 12345,
+    };
+    // @ts-expect-error songLengthMs without metadata is not a valid mode
+    const entries = assembleChartFiles(options);
+
+    expect(songIniText(entries)).toContain('song_length = 999');
+  });
+
   test('supplying metadata still stamps identity and ratings', () => {
     const ini = songIniText(
       assembleChartFiles({

--- a/spotify-clonehero-next/lib/chart-export/__tests__/package.test.ts
+++ b/spotify-clonehero-next/lib/chart-export/__tests__/package.test.ts
@@ -1,0 +1,52 @@
+/**
+ * Container packaging shared by every export flow ({@link packageChartFiles}).
+ */
+
+import {unzipSync, strFromU8} from 'fflate';
+import type {File as FileEntry} from '@eliwhite/scan-chart';
+import {packageChartFiles} from '../package';
+
+const FILES: FileEntry[] = [
+  {fileName: 'notes.chart', data: new TextEncoder().encode('[Song]\n{\n}\n')},
+  {
+    fileName: 'song.ini',
+    data: new TextEncoder().encode('[song]\nname = Test\n'),
+  },
+  {fileName: 'song.opus', data: new Uint8Array([1, 2, 3, 4])},
+];
+
+describe('packageChartFiles', () => {
+  it('zips every entry verbatim under its own name', async () => {
+    const {blob, extension} = packageChartFiles(FILES, 'zip');
+
+    expect(extension).toBe('zip');
+    expect(blob.type).toBe('application/zip');
+
+    const zip = unzipSync(new Uint8Array(await blob.arrayBuffer()));
+    expect(Object.keys(zip).sort()).toEqual([
+      'notes.chart',
+      'song.ini',
+      'song.opus',
+    ]);
+    expect(strFromU8(zip['notes.chart'])).toBe('[Song]\n{\n}\n');
+    expect(Array.from(zip['song.opus'])).toEqual([1, 2, 3, 4]);
+  });
+
+  it('packages sng as an octet-stream', async () => {
+    const {blob, extension} = packageChartFiles(FILES, 'sng');
+
+    expect(extension).toBe('sng');
+    expect(blob.type).toBe('application/octet-stream');
+
+    // The SNG header identifies the container; song.ini is folded into its
+    // metadata rather than shipping as a file entry.
+    const bytes = new Uint8Array(await blob.arrayBuffer());
+    expect(strFromU8(bytes.slice(0, 6))).toBe('SNGPKG');
+  });
+
+  it('produces different containers from the same entries', async () => {
+    const zip = await packageChartFiles(FILES, 'zip').blob.arrayBuffer();
+    const sng = await packageChartFiles(FILES, 'sng').blob.arrayBuffer();
+    expect(new Uint8Array(zip)).not.toEqual(new Uint8Array(sng));
+  });
+});

--- a/spotify-clonehero-next/lib/chart-export/assemble.ts
+++ b/spotify-clonehero-next/lib/chart-export/assemble.ts
@@ -65,7 +65,8 @@ function canonicalChartFileName(fileName: string): string {
   return /\.(mid|midi)$/i.test(fileName) ? 'notes.mid' : 'notes.chart';
 }
 
-export interface AssembleChartFilesOptions {
+/** Options common to both assembly modes — see {@link AssembleChartFilesOptions}. */
+interface ChartSourceOptions {
   /**
    * Valid `.chart` text. Mutually exclusive with `chartFile`/`chartDoc` —
    * supply exactly one. Convenience for callers that only ever deal in
@@ -86,18 +87,6 @@ export interface AssembleChartFilesOptions {
    * carries would be lost.
    */
   chartDoc?: ChartDocument;
-  /**
-   * Metadata to stamp into song.ini, for flows that MINT a chart (drum
-   * transcription, /difficulties): the caller's name/artist/charter replace
-   * whatever the document carried, the chart is declared `pro_drums` with a
-   * drums difficulty, and `song_length` is (re)computed.
-   *
-   * Omit for a ROUND-TRIP export — a flow that edits somebody else's chart
-   * and hands it back (/add-lyrics). The document's own metadata then ships
-   * untouched: a guitar-only chart must not come back advertising rated pro
-   * drums, and the original charter keeps their credit.
-   */
-  metadata?: ChartPackageMetadata;
   /** Audio stems to bundle alongside the chart. */
   audioSources?: PackageAudioSource[];
   /**
@@ -108,14 +97,44 @@ export interface AssembleChartFilesOptions {
    * entry is skipped, since those are already authoritative above.
    */
   extraAssets?: FileEntry[];
+}
+
+/**
+ * MINT mode: the caller is creating a chart (drum transcription,
+ * /difficulties). Its name/artist/charter replace whatever the document
+ * carried, the chart is declared `pro_drums` with a drums difficulty, and
+ * `song_length` is (re)computed.
+ */
+interface MintedChartOptions extends ChartSourceOptions {
+  metadata: ChartPackageMetadata;
   /**
    * Song length in milliseconds, stamped as `song.ini`'s `song_length`. Best
    * sourced from the actual (decoded) audio duration. Omitted, `undefined`,
-   * or non-positive falls back to the chart's own last event time. Ignored
-   * without `metadata` — a round-trip export rewrites nothing.
+   * or non-positive falls back to the chart's own last event time.
    */
   songLengthMs?: number;
 }
+
+/**
+ * ROUND-TRIP mode: the caller is editing somebody else's chart and handing it
+ * back (/add-lyrics). The document's own metadata ships untouched — a
+ * guitar-only chart must not come back advertising rated pro drums, and the
+ * original charter keeps their credit.
+ *
+ * `metadata` and `songLengthMs` are typed away rather than merely ignored, so
+ * a caller that means to stamp can't half-configure it and silently ship an
+ * unstamped chart.
+ */
+interface RoundTripChartOptions extends ChartSourceOptions {
+  metadata?: undefined;
+  songLengthMs?: undefined;
+}
+
+/** Assembly is either a mint or a round trip; the presence of `metadata`
+ *  picks the mode. See {@link MintedChartOptions} / {@link RoundTripChartOptions}. */
+export type AssembleChartFilesOptions =
+  | MintedChartOptions
+  | RoundTripChartOptions;
 
 /** The chart's own duration, in milliseconds: the latest point any note ends
  * or an end event fires, across every track. Used as the `song_length`

--- a/spotify-clonehero-next/lib/chart-export/assemble.ts
+++ b/spotify-clonehero-next/lib/chart-export/assemble.ts
@@ -86,8 +86,18 @@ export interface AssembleChartFilesOptions {
    * carries would be lost.
    */
   chartDoc?: ChartDocument;
-  /** Metadata to stamp into song.ini. */
-  metadata: ChartPackageMetadata;
+  /**
+   * Metadata to stamp into song.ini, for flows that MINT a chart (drum
+   * transcription, /difficulties): the caller's name/artist/charter replace
+   * whatever the document carried, the chart is declared `pro_drums` with a
+   * drums difficulty, and `song_length` is (re)computed.
+   *
+   * Omit for a ROUND-TRIP export — a flow that edits somebody else's chart
+   * and hands it back (/add-lyrics). The document's own metadata then ships
+   * untouched: a guitar-only chart must not come back advertising rated pro
+   * drums, and the original charter keeps their credit.
+   */
+  metadata?: ChartPackageMetadata;
   /** Audio stems to bundle alongside the chart. */
   audioSources?: PackageAudioSource[];
   /**
@@ -101,7 +111,8 @@ export interface AssembleChartFilesOptions {
   /**
    * Song length in milliseconds, stamped as `song.ini`'s `song_length`. Best
    * sourced from the actual (decoded) audio duration. Omitted, `undefined`,
-   * or non-positive falls back to the chart's own last event time.
+   * or non-positive falls back to the chart's own last event time. Ignored
+   * without `metadata` — a round-trip export rewrites nothing.
    */
   songLengthMs?: number;
 }
@@ -126,14 +137,57 @@ function chartEndMs(parsedChart: ParsedChart): number {
 }
 
 /**
+ * Apply a minting flow's identity + ratings to a chart's metadata, or hand
+ * the chart back untouched when no metadata was supplied (round-trip export).
+ */
+function stampMetadata(
+  parsedChart: ParsedChart,
+  metadata: ChartPackageMetadata | undefined,
+  songLengthMs: number | undefined,
+): ParsedChart {
+  if (!metadata) return parsedChart;
+
+  const existing = parsedChart.metadata;
+  // Declare a drums difficulty so scan-chart / chart managers see a rated
+  // chart. The chart file alone carries this; any diff_drums the pipeline
+  // set in song.ini separately is gone by here; default to 0 when absent.
+  const diffDrums =
+    existing.diff_drums != null && existing.diff_drums >= 0
+      ? existing.diff_drums
+      : 0;
+  // Shallow-clone rather than mutate `parsedChart` in place — a
+  // caller-supplied `chartDoc` (the `chartDoc` option) may be reused
+  // elsewhere and shouldn't be silently modified by this call.
+  return {
+    ...parsedChart,
+    metadata: {
+      ...existing,
+      name: metadata.name,
+      artist: metadata.artist,
+      charter: metadata.charter.trim() || 'MusicCharts.tools',
+      pro_drums: true,
+      diff_drums: diffDrums,
+      // Phase Shift "real drums" difficulty — kept equal to diff_drums since
+      // this pipeline doesn't distinguish a separate real-drums chart.
+      diff_drums_real: diffDrums,
+      song_length:
+        songLengthMs != null && songLengthMs > 0
+          ? Math.round(songLengthMs)
+          : chartEndMs(parsedChart),
+    },
+  };
+}
+
+/**
  * Assemble the flat file list for a chart package.
  *
  * Parses the chart (`chartText` as `.chart`, or `chartFile` in whichever
- * format it names), stamps the supplied metadata (name/artist/charter, plus
- * `pro_drums`), and runs it back through `writeChartFolder` so the chart file
- * and `song.ini` are regenerated consistently — in the SAME format it was
- * given (a `.mid`-sourced chart-flow project stays `.mid`; `writeChartFolder`
- * doesn't convert). Audio sources are appended verbatim.
+ * format it names), stamps `metadata` when the caller is minting a chart (see
+ * the option's doc for the two modes), and runs it back through
+ * `writeChartFolder` so the chart file and `song.ini` are regenerated
+ * consistently — in the SAME format it was given (a `.mid`-sourced chart-flow
+ * project stays `.mid`; `writeChartFolder` doesn't convert). Audio sources are
+ * appended verbatim.
  */
 export function assembleChartFiles({
   chartText,
@@ -171,35 +225,11 @@ export function assembleChartFiles({
       };
       return readChart([inputFile]);
     })();
-  const existing = chartDoc.parsedChart.metadata;
-  // Declare a drums difficulty so scan-chart / chart managers see a rated
-  // chart. The chart file alone carries this; any diff_drums the pipeline
-  // set in song.ini separately is gone by here; default to 0 when absent.
-  const diffDrums =
-    existing.diff_drums != null && existing.diff_drums >= 0
-      ? existing.diff_drums
-      : 0;
-  // Shallow-clone rather than mutate `chartDoc.parsedChart` in place — a
-  // caller-supplied `chartDoc` (the `chartDoc` option) may be reused
-  // elsewhere and shouldn't be silently modified by this call.
-  const stampedParsedChart: ParsedChart = {
-    ...chartDoc.parsedChart,
-    metadata: {
-      ...existing,
-      name: metadata.name,
-      artist: metadata.artist,
-      charter: metadata.charter.trim() || 'MusicCharts.tools',
-      pro_drums: true,
-      diff_drums: diffDrums,
-      // Phase Shift "real drums" difficulty — kept equal to diff_drums since
-      // this pipeline doesn't distinguish a separate real-drums chart.
-      diff_drums_real: diffDrums,
-      song_length:
-        songLengthMs != null && songLengthMs > 0
-          ? Math.round(songLengthMs)
-          : chartEndMs(chartDoc.parsedChart),
-    },
-  };
+  const stampedParsedChart: ParsedChart = stampMetadata(
+    chartDoc.parsedChart,
+    metadata,
+    songLengthMs,
+  );
 
   const entries: FileEntry[] = writeChartFolder({
     parsedChart: stampedParsedChart,

--- a/spotify-clonehero-next/lib/chart-export/index.ts
+++ b/spotify-clonehero-next/lib/chart-export/index.ts
@@ -1,5 +1,7 @@
 export {exportAsZip} from './zip';
 export {exportAsSng} from './sng';
+export {packageChartFiles} from './package';
+export type {ChartPackage, PackageFormat} from './package';
 export {assembleChartFiles, chartPackageFileName} from './assemble';
 export type {
   ChartPackageMetadata,

--- a/spotify-clonehero-next/lib/chart-export/package.ts
+++ b/spotify-clonehero-next/lib/chart-export/package.ts
@@ -1,0 +1,49 @@
+/**
+ * Container packaging: a flat chart file list plus a choice of container,
+ * out the other side a downloadable Blob.
+ *
+ * The last step of every export flow in the app. Kept here so the three
+ * callers (the editor's export dialog, /difficulties, /add-lyrics) share one
+ * definition of what a `.zip` and a `.sng` download are, rather than each
+ * re-deriving the MIME type and the sng-bytes-to-Blob wrapping.
+ */
+
+import type {File as FileEntry} from '@eliwhite/scan-chart';
+import {exportAsZip} from './zip';
+import {exportAsSng} from './sng';
+
+/** The outer container a chart package is downloaded as. Distinct from the
+ *  chart file's own format (`.chart` / `.mid`) inside it. */
+export type PackageFormat = 'zip' | 'sng';
+
+export interface ChartPackage {
+  blob: Blob;
+  /** The container's file extension, without the dot — suitable for
+   *  {@link chartPackageFileName}. */
+  extension: PackageFormat;
+}
+
+/**
+ * Package assembled chart files into the requested container.
+ *
+ * `.sng` is an uncompressed container that pulls song.ini into its header
+ * metadata (see {@link exportAsSng}); `.zip` is a plain Clone Hero song
+ * folder. Neither branch inspects or rewrites the entries — whatever the
+ * caller assembled is what ships.
+ */
+export function packageChartFiles(
+  files: FileEntry[],
+  format: PackageFormat,
+): ChartPackage {
+  if (format === 'sng') {
+    const sngBytes = exportAsSng(files);
+    return {
+      blob: new Blob([sngBytes as Uint8Array<ArrayBuffer>], {
+        type: 'application/octet-stream',
+      }),
+      extension: 'sng',
+    };
+  }
+
+  return {blob: exportAsZip(files), extension: 'zip'};
+}


### PR DESCRIPTION
## Summary

The `/add-lyrics` export was discarding all manual timing fixes users made in the editor (lyric drags, phrase resizes, text changes). The root cause was that the download handler was re-deriving the chart from the aligner's output instead of serializing the editor session's live document. This PR fixes the export to use the editor's live `state.chartDoc` and refactors the export infrastructure to support both "minting" (creating new charts with stamped metadata) and "round-trip" (editing existing charts without modification) modes.

## Key Changes

- **New `/add-lyrics` export module** (`app/add-lyrics/export-chart.ts`): Packages the editor's live document in its original format (`.sng` or `.zip`) with the original filename, using round-trip assembly mode that preserves the chart's existing metadata and ratings.

- **Refactored `assembleChartFiles` into two modes** (`lib/chart-export/assemble.ts`):
  - **Minting mode** (`MintedChartOptions`): Supplies `metadata` to stamp identity, charter credit, and drum ratings onto a newly-created chart (used by drum transcription and `/difficulties` flows).
  - **Round-trip mode** (`RoundTripChartOptions`): Omits `metadata` to ship the document's own identity untouched (used by `/add-lyrics`). The type system enforces this distinction — `songLengthMs` is only valid with `metadata`, preventing half-configured stamps.

- **Extracted container packaging** (`lib/chart-export/package.ts`): Unified `.zip` and `.sng` download logic into `packageChartFiles()`, shared by all three export flows (editor dialog, `/difficulties`, `/add-lyrics`). Eliminates duplicate MIME type and Blob wrapping code.

- **Updated `/add-lyrics` editor** (`app/add-lyrics/AddLyricsClient.tsx`):
  - Removed snapshot of `editorData` that captured the chart at editor-prep time; now reads `state.chartDoc` live from the session.
  - Disabled the Download button until the editor is prepared (prevents exporting stale state).
  - Simplified download handler to call `buildChartExport()` instead of manually assembling files.

- **Comprehensive test coverage**:
  - `app/add-lyrics/__tests__/export-chart.test.ts`: Verifies that manual lyric timing edits survive the download.
  - `lib/chart-export/__tests__/assemble-roundtrip.test.ts`: Ensures round-trip mode preserves original metadata and doesn't stamp drum ratings onto charts that never had them.
  - `lib/chart-export/__tests__/package.test.ts`: Tests container packaging for both `.zip` and `.sng` formats.

## Notable Implementation Details

- The editor session's `state.chartDoc` is the single source of truth for the chart state — every highway edit (lyric drag, phrase resize, text change) is dispatched onto it, making it the only document that carries the user's manual fixes.
- Round-trip mode uses TypeScript's union type system to enforce that `metadata` and `songLengthMs` are mutually exclusive with the absence of `metadata`, preventing accidental half-configured stamps at compile time.
- The chart's own metadata (name, artist, charter, ratings) is shallow-cloned rather than mutated in place, so caller-supplied documents can be safely reused elsewhere without side effects.

https://claude.ai/code/session_01Eu97QhNy6TUZkqR9k4u9k5